### PR TITLE
Add build that includes PostGIS extension

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -1,0 +1,37 @@
+FROM timescale/timescaledb:0.0.11-beta
+
+MAINTAINER Timescale https://www.timescale.com
+ENV POSTGIS_VERSION 2.3.2
+
+RUN set -ex \
+    && apk add --no-cache --virtual .fetch-deps \
+                ca-certificates \
+                openssl \
+                tar \
+    && apk add --no-cache --virtual .postgis-deps --repository http://nl.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && apk add --no-cache --virtual .build-deps --repository http://nl.alpinelinux.org/alpine/edge/testing \
+        postgresql-dev \
+        perl \
+        file \
+        geos-dev \
+        libxml2-dev \
+        gdal-dev \
+        proj4-dev \
+        gcc g++ \
+        make \
+    && cd /tmp \
+    && wget http://download.osgeo.org/postgis/source/postgis-${POSTGIS_VERSION}.tar.gz -O - | tar -xz \
+    && chown root:root -R postgis-${POSTGIS_VERSION} \
+    && cd /tmp/postgis-${POSTGIS_VERSION} \
+    && ./configure \
+    && echo "PERL = /usr/bin/perl" >> extensions/postgis/Makefile \
+    && echo "PERL = /usr/bin/perl" >> extensions/postgis_topology/Makefile \
+    && make -s \
+    && make -s install \
+    && cd / \
+    \
+    && rm -rf /tmp/postgis-${POSTGIS_VERSION} \
+    && apk del .fetch-deps .build-deps

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -1,0 +1,21 @@
+NAME=timescaledb-postgis
+ORG=timescale
+VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile)
+
+default: image
+
+.build_postgis_$(VERSION): Dockerfile
+	docker build -t $(ORG)/$(NAME) .
+	docker tag $(ORG)/$(NAME):latest $(ORG)/$(NAME):$(VERSION)
+	touch .build_$(VERSION)
+
+image: .build_postgis_$(VERSION)
+
+push: image
+	docker push $(ORG)/$(NAME):latest
+	docker push $(ORG)/$(NAME):$(VERSION)
+
+clean:
+	rm -f *~
+
+.PHONY: default image push clean

--- a/postgis/README.md
+++ b/postgis/README.md
@@ -1,0 +1,5 @@
+## TimescaleDB + PostGIS
+
+This Docker image adds the popular [PostGIS](http://postgis.net)
+extension to the standard TimescaleDB image. This allows creating
+hypertables that include spatial and geographical object columns.


### PR DESCRIPTION
This PR includes an optional Docker build that adds the PostGIS extension to our standard Docker image.