### PR TITLE
Update Dockerfile to 0.0.12-beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:9.6.3-alpine
 
 MAINTAINER Timescale https://www.timescale.com
 
-ENV TIMESCALEDB_VERSION 0.0.11-beta
+ENV TIMESCALEDB_VERSION 0.0.12-beta
 
 RUN set -ex \
     && apk add --no-cache --virtual .fetch-deps \

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -1,4 +1,4 @@
-FROM timescale/timescaledb:0.0.11-beta
+FROM timescale/timescaledb:latest
 
 MAINTAINER Timescale https://www.timescale.com
 ENV POSTGIS_VERSION 2.3.2


### PR DESCRIPTION
Also the PostGIS image now sources from timescaledb:latest which
should always be the latest released version.