### PR TITLE
Don't disable postgres password authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Timescale https://www.timescale.com
 
 ENV TIMESCALEDB_VERSION 0.10.0
 
+COPY docker-entrypoint-initdb.d/reenable_auth.sh /docker-entrypoint-initdb.d/
+
 RUN set -ex \
     && apk add --no-cache --virtual .fetch-deps \
                 ca-certificates \

--- a/docker-entrypoint-initdb.d/reenable_auth.sh
+++ b/docker-entrypoint-initdb.d/reenable_auth.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# reenable password authentication
+sed -i "s/host all all all trust/host all all all md5/" /var/lib/postgresql/data/pg_hba.conf


### PR DESCRIPTION
When POSTGRES_PASSWORD is not set on the initial container 
when initdb is run then the docker entrypoint of the postgres
container will disable password checks for everybody.
This change will overwrite that behaviour and keep password
checks intact.