### PR TITLE
update postgis to 2.5.0, add json-c-dev package for json support

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -3,7 +3,7 @@ FROM timescale/timescaledb:0.12.1-${PG_VERSION_TAG}
 
 MAINTAINER Timescale https://www.timescale.com
 ARG POSTGIS_VERSION
-ENV POSTGIS_VERSION ${POSTGIS_VERSION:-2.4.4}
+ENV POSTGIS_VERSION ${POSTGIS_VERSION:-2.5.0}
 
 RUN set -ex \
     && apk add --no-cache --virtual .fetch-deps \
@@ -28,6 +28,7 @@ RUN set -ex \
         gdal-dev \
         proj4-dev \
         protobuf-c-dev \
+        json-c-dev \
         gcc g++ \
         make \
     && cd /tmp \

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -7,10 +7,10 @@ default: image
 
 .build_postgis_$(VERSION)_$(PG_VER): Dockerfile
 ifeq ($(PG_VER),pg9.6)
-	docker build --build-arg POSTGIS_VERSION=2.3.7 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
+	docker build --build-arg POSTGIS_VERSION=2.5.0 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):latest
 else
-	docker build --build-arg POSTGIS_VERSION=2.4.4 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
+	docker build --build-arg POSTGIS_VERSION=2.5.0 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
 endif
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	touch .build_postgis_$(VERSION)_$(PG_VER)


### PR DESCRIPTION
Current image is throwing below error for postgis query.
```
2018-09-24 19:59:51.013 UTC [70] ERROR:  You need JSON-C for ST_GeomFromGeoJSON
```

adding json-c-dev, fixes the issue. Tested manually. Also updated postgis to 2.5.0, which supports postgres 11 & geos 3.7, waiting for timescale-postgres v11. [https://postgis.net/2018/09/23/postgis-2.5.0/](https://postgis.net/2018/09/23/postgis-2.5.0/)