### PR TITLE
Add client tools and run timescaledb-tune

### DIFF
--- a/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
+++ b/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Tune database using timescaledb-tune
+/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${PGDATA}/postgresql.conf"


### PR DESCRIPTION
This adds timescaledb-tune and timescaledb-parallel-copy to the
Docker image for easier usage of these tools for Docker users. In
addition, timescaledb-tune is now run on the initial run of the
Docker image so that the user does not have to manually invoke it.
This should make Docker setup very easy.