### PR TITLE
Added Travis build file with job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+sudo: 'required'
+
+dist: trusty
+
+services:
+  - 'docker'
+
+# Useful for forks by other contributors
+env:
+  global:
+  - ORG=$DOCKER_USERNAME
+
+matrix:
+  include:
+    - env: PG_VER=pg9.6
+    - env: PG_VER=pg10
+    - env: PG_VER=pg11
+    - env: PG_VER=pg11-bitnami
+  fast_finish: true
+
+script:
+  - 'make image'
+
+after_success:
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
+      make push;
+    else
+      echo "Build succeeded in non-master branch"
+    fi
+
+# Uncomment if only commits to master require builds
+# branches:
+#   except:
+#     - master
+
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-NAME=timescaledb
-ORG=timescale
-PG_VER=pg10
-VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
+NAME?=timescaledb
+ORG?=timescale
+PG_VER?=pg10
+VERSION?=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
 
 default: image
 


### PR DESCRIPTION
Addresses https://github.com/timescale/timescaledb-docker/issues/22

Proof of integration:
Travis Build: https://travis-ci.com/sgama/timescaledb-docker/builds/98749858
Dockerhub Repository: https://cloud.docker.com/repository/docker/solardesigner/timescaledb/general

To get this CICD pipeline setup, you will first need to hook this repository into TravisCI.
Then configure the Environment Variables within the settings of the Travis Job for your Dockerhub repo. 

I used the variables `DOCKER_USERNAME` and `DOCKER_PASSWORD` which contained the credentials for Dockerhub. Be sure to uncheck the slider for "Displaying value in the build log".
