### PR TITLE
Add build targets for OSS-only images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apk update && apk add --no-cache git \
 ARG PG_VERSION
 FROM postgres:${PG_VERSION}-alpine AS oldversions
 ARG PG_VERSION
+ARG OSS_ONLY
 RUN set -ex \
     && apk add --no-cache --virtual .fetch-deps \
                 ca-certificates \
@@ -50,7 +51,7 @@ RUN set -ex \
     && cd /build/timescaledb \
     # This script is a bit ugly, but once all the old versions are buildable
     # on PG11, we can remove the 'if' guard
-    && echo "if [ \"$(echo ${PG_VERSION} | cut -c1-2)\" != \"11\" ] || [ "\${OLD_VERSION}" \> "1.0.1" ]; then cd /build/timescaledb && rm -fr build && git checkout \${OLD_VERSION} && ./bootstrap -DPROJECT_INSTALL_METHOD=\"docker\" && cd build && make install; fi" > ./build_old.sh \
+    && echo "if [ \"$(echo ${PG_VERSION} | cut -c1-2)\" != \"11\" ] || [ "\${OLD_VERSION}" \> "1.0.1" ]; then cd /build/timescaledb && rm -fr build && git checkout \${OLD_VERSION} && ./bootstrap -DPROJECT_INSTALL_METHOD=\"docker\"${OSS_ONLY} && cd build && make install; fi" > ./build_old.sh \
     && chmod +x ./build_old.sh
 
 #####
@@ -87,6 +88,7 @@ RUN \
 ############################
 ARG PG_VERSION
 FROM postgres:${PG_VERSION}-alpine
+ARG OSS_ONLY
 
 MAINTAINER Timescale https://www.timescale.com
 
@@ -120,7 +122,7 @@ RUN set -ex \
     # Build current version \
     && cd /build/timescaledb && rm -fr build \
     && git checkout ${TIMESCALEDB_VERSION} \
-    && ./bootstrap -DPROJECT_INSTALL_METHOD="docker" \
+    && ./bootstrap -DPROJECT_INSTALL_METHOD="docker"${OSS_ONLY} \
     && cd build && make install \
     && cd ~ \
     \

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,27 @@
 NAME=timescaledb
 ORG=timescale
 PG_VER=pg10
+PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
 
 default: image
 
+.build_$(VERSION)_$(PG_VER)_oss: Dockerfile
+	docker build --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER)-oss .
+	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-oss $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-oss
+	touch .build_$(VERSION)_$(PG_VER)_oss
+
 .build_$(VERSION)_$(PG_VER): Dockerfile
+	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
 ifeq ($(PG_VER),pg9.6)
-	docker build --build-arg PG_VERSION=9.6.10 -t $(ORG)/$(NAME):latest-$(PG_VER) .
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):latest
-else ifeq ($(PG_VER),pg10)
-	docker build --build-arg PG_VERSION=10.5 -t $(ORG)/$(NAME):latest-$(PG_VER) .
-else
-	docker build --build-arg PG_VERSION=11.1 -t $(ORG)/$(NAME):latest-$(PG_VER) .
 endif
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	touch .build_$(VERSION)_$(PG_VER)
 
 image: .build_$(VERSION)_$(PG_VER)
+
+oss: .build_$(VERSION)_$(PG_VER)_oss
 
 push: image
 	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)


### PR DESCRIPTION
For users who want to continue using TimescaleDB, but only want
to use completely open-source bits (i.e., no TSL code), we add
build targets to generate images for that. Additionally the
Makefile is simplified by defining a new PG_VER_NUMBER that can
be used to pull the right up-to-date image for each PostgreSQL
major version. In the future we should remove PG_VER and simplify
the Makefile further.