### PR TITLE
Pass docker resource limits to timescaledb-tune by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,27 @@ $ docker run -d --name some-timescaledb -p 5432:5432 --env TIMESCALEDB_TELEMETRY
 ```
 
 Note that if the cluster has previously been initialized, you should not use this environment variable to set the level of telemetry. Instead, follow the [instructions](https://docs.timescale.com/using-timescaledb/telemetry) in our docs to disable telemetry once a cluster is running.
+
+### Notes on timescaledb-tune
+
+We run `timescaledb-tune` automatically on container initialization. By default,
+`timescaledb-tune` uses system calls to retrieve an instance's available CPU
+and memory. In docker images, these system calls reflect the available resources
+on the **host**. For cases where a container is allocated all available
+resources on a host, this is fine. But many use cases involve limiting the
+amount of resources a container (or the docker daemon) can have on the host.
+Therefore, this image looks in the cgroups metadata to determine the
+docker-defined limit sizes then passes those values to `timescaledb-tune`.
+
+To specify your own limits, use the `TS_TUNE_MEMORY` and `TS_TUNE_NUM_CPUS`
+environment variables at runtime:
+
+```
+$ docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password -e TS_TUNE_MEMORY=4GB -e TS_TUNE_NUM_CPUS=4 timescale/timescaledb:latest-pg11
+```
+
+To not run `timescaledb-tune` at all, use the `NO_TS_TUNE` environment variable:
+
+```
+$ docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password -e NO_TS_TUNE=true timescale/timescaledb:latest-pg11
+```

--- a/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
+++ b/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
@@ -1,8 +1,62 @@
 #!/bin/bash
 
-if [ -z "${PGDATA}" ] && [ ! -z "${BITNAMI_IMAGE_VERSION}" ]; then
-	PGDATA=${POSTGRESQL_DATA_DIR}
+NO_TS_TUNE=${NO_TS_TUNE:-""}
+TS_TUNE_MEMORY=${TS_TUNE_MEMORY:-""}
+TS_TUNE_NUM_CPUS=${TS_TUNE_NUM_CPUS:-""}
+
+if [ ! -z "${NO_TS_TUNE}" ]; then
+    # The user has explicitly requested not to run timescaledb-tune; exit this script
+    exit 0
 fi
 
-# Tune database using timescaledb-tune
-/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${PGDATA}/postgresql.conf"
+
+if [ -z "${PGDATA}" ] && [ ! -z "${BITNAMI_IMAGE_VERSION}" ]; then
+    PGDATA=${POSTGRESQL_DATA_DIR}
+fi
+
+if [ -z "${TS_TUNE_MEMORY}" ]; then
+    # See if we can get the container's total allocated memory from the cgroups metadata
+    if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+        TS_TUNE_MEMORY=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+        if [ $(echo -n $TS_TUNE_MEMORY) -gt $(free -b | grep 'Mem' | awk '{print $2}') ]; then
+            # Something weird is going on if the cgroups memory limit exceeds the total available
+            # amount of system memory reported by "free", which is the total amount of memory available on the host.
+            # Most likely, it is this issue: https://github.com/moby/moby/issues/18087 (if no limit is
+            # set, the max limit is set to the max 64 bit integer). In this case, we just leave
+            # TS_TUNE_MEMORY blank and let timescaledb-tune derive the memory itself using syscalls.
+            TS_TUNE_MEMORY=""
+        else
+            # Convert the bytes to MB so it plays nicely with timescaledb-tune
+            TS_TUNE_MEMORY="$(echo $TS_TUNE_MEMORY | awk '{print int($1 / 1024 / 1024)}')MB"
+        fi
+    fi
+fi
+
+if [ -z "${TS_TUNE_NUM_CPUS}" ]; then
+    # See if we can get the container's available CPUs from the cgroups metadata
+    if [ -f /sys/fs/cgroup/cpuset/cpuset.cpus ]; then
+        TS_TUNE_NUM_CPUS=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+        if [[ ${TS_TUNE_NUM_CPUS} == *-* ]]; then
+            # The CPU limits have been defined as a range (e.g., 0-3 for 4 CPUs). Subtract them and add 1
+            # to convert the range to the number of CPUs.
+            TS_TUNE_NUM_CPUS=$(echo ${TS_TUNE_NUM_CPUS} | tr "-" " " | awk '{print ($2 - $1) + 1}')
+        elif [[ ${TS_TUNE_NUM_CPUS} == *,* ]]; then
+            # The CPU limits have been defined as a comma separated list (e.g., 0,1,2,3 for 4 CPUs). Count each CPU
+            TS_TUNE_NUM_CPUS=$(echo ${TS_TUNE_NUM_CPUS} | tr "," "\n" | wc -l)
+        elif [ $(echo -n ${TS_TUNE_NUM_CPUS} | wc -c) -eq 1 ]; then
+            # The CPU limit has been defined as a single numbered CPU. In this case the CPU limit is 1
+            # regardless of what that number is
+            TS_TUNE_NUM_CPUS=1
+        fi
+    fi
+fi
+
+if [ ! -z "${TS_TUNE_MEMORY}" ]; then
+    TS_TUNE_MEMORY_FLAGS=--memory="${TS_TUNE_MEMORY}"
+fi
+
+if [ ! -z "${TS_TUNE_NUM_CPUS}" ]; then
+    TS_TUNE_NUM_CPUS_FLAGS=--cpus=${TS_TUNE_NUM_CPUS}
+fi
+
+/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${PGDATA}/postgresql.conf" ${TS_TUNE_MEMORY_FLAGS} ${TS_TUNE_NUM_CPUS_FLAGS}


### PR DESCRIPTION
This fixes an issue where the system calls used by timescaledb-tune were
reporting the resources available on a container's host, which often
do not match the resources allocated to a given container. To fix this,
we inspect the cgroups metadata to determine the actual resource limits
imposed on the container. We also allow users to override these values.