### PR TITLE
Updated upstream Bitnami image versions

### DIFF
--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -153,5 +153,6 @@ RUN set -ex \
         /var/lib/apt/lists/* \
         /tmp/*               \
         /var/tmp/*
+RUN sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /opt/bitnami/postgresql/share/postgresql.conf.sample
 
 USER 1001

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -7,12 +7,12 @@ default: image
 
 .build_$(VERSION)_$(PG_VER): Dockerfile
 ifeq ($(PG_VER),pg9.6)
-	docker build -f ./Dockerfile --build-arg PG_VERSION=9.6.11 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
+	docker build -f ./Dockerfile --build-arg PG_VERSION=9.6.13 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-bitnami $(ORG)/$(NAME):latest-bitnami
 else ifeq ($(PG_VER),pg10)
-	docker build -f ./Dockerfile --build-arg PG_VERSION=10.6.0 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
+	docker build -f ./Dockerfile --build-arg PG_VERSION=10.8.0 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
 else
-	docker build -f ./Dockerfile --build-arg PG_VERSION=11.1.0 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
+	docker build -f ./Dockerfile --build-arg PG_VERSION=11.3.0 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
 endif
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-bitnami $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-bitnami
 	touch .build_$(VERSION)_$(PG_VER)-bitnami

--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -1,31 +1,35 @@
 #!/bin/bash
 
 # Checks to support bitnami image with same scripts so they stay in sync
-if [ ! -z "${BITNAMI_IMAGE_VERSION}" ]; then
-	if [ -z "${POSTGRES_USER}" ]; then
+if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
+	if [ -z "${POSTGRES_USER:-}" ]; then
 		POSTGRES_USER=${POSTGRESQL_USERNAME}
 	fi
 
-	if [ -z "${POSTGRES_DB}" ]; then
+	if [ -z "${POSTGRES_DB:-}" ]; then
 		POSTGRES_DB=${POSTGRESQL_DATABASE}
 	fi
 
-	if [ -z "${PGDATA}" ]; then
+	if [ -z "${PGDATA:-}" ]; then
 		PGDATA=${POSTGRESQL_DATA_DIR}
 	fi
 fi
 
+if [ -z "${POSTGRESQL_CONF_DIR:-}" ]; then
+	POSTGRESQL_CONF_DIR=${PGDATA}
+fi
+
 TS_TELEMETRY='basic'
-if [ "${TIMESCALEDB_TELEMETRY}" == "off" ]; then
+if [ "${TIMESCALEDB_TELEMETRY:-}" == "off" ]; then
 	TS_TELEMETRY='off'
 fi
 
-echo "timescaledb.telemetry_level=${TS_TELEMETRY}" >> ${PGDATA}/postgresql.conf
+echo "timescaledb.telemetry_level=${TS_TELEMETRY}" >> ${POSTGRESQL_CONF_DIR}/postgresql.conf
 
 # create extension timescaledb in initial databases
 psql -U "${POSTGRES_USER}" postgres -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
 psql -U "${POSTGRES_USER}" template1 -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
 
-if [ "${POSTGRES_DB}" != 'postgres' ]; then
+if [ "${POSTGRES_DB:-postgres}" != 'postgres' ]; then
   psql -U "${POSTGRES_USER}" "${POSTGRES_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
 fi

--- a/docker-entrypoint-initdb.d/001_reenable_auth.sh
+++ b/docker-entrypoint-initdb.d/001_reenable_auth.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ -z "${PGDATA}" ] && [ ! -z "${BITNAMI_IMAGE_VERSION}" ]; then
-	PGDATA=${POSTGRESQL_DATA_DIR}
+if [ -z "${POSTGRESQL_CONF_DIR:-}" ]; then
+        POSTGRESQL_CONF_DIR=${PGDATA}
 fi
 
 # reenable password authentication
-sed -i "s/host all all all trust/host all all all md5/" "${PGDATA}/pg_hba.conf"
+sed -i "s/host all all all trust/host all all all md5/" "${POSTGRESQL_CONF_DIR}/pg_hba.conf"

--- a/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
+++ b/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
@@ -4,17 +4,17 @@ NO_TS_TUNE=${NO_TS_TUNE:-""}
 TS_TUNE_MEMORY=${TS_TUNE_MEMORY:-""}
 TS_TUNE_NUM_CPUS=${TS_TUNE_NUM_CPUS:-""}
 
-if [ ! -z "${NO_TS_TUNE}" ]; then
+if [ ! -z "${NO_TS_TUNE:-}" ]; then
     # The user has explicitly requested not to run timescaledb-tune; exit this script
     exit 0
 fi
 
 
-if [ -z "${PGDATA}" ] && [ ! -z "${BITNAMI_IMAGE_VERSION}" ]; then
-    PGDATA=${POSTGRESQL_DATA_DIR}
+if [ -z "${POSTGRESQL_CONF_DIR:-}" ]; then
+        POSTGRESQL_CONF_DIR=${PGDATA}
 fi
 
-if [ -z "${TS_TUNE_MEMORY}" ]; then
+if [ -z "${TS_TUNE_MEMORY:-}" ]; then
     # See if we can get the container's total allocated memory from the cgroups metadata
     if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
         TS_TUNE_MEMORY=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
@@ -44,7 +44,7 @@ if [ -z "${TS_TUNE_MEMORY}" ]; then
     fi
 fi
 
-if [ -z "${TS_TUNE_NUM_CPUS}" ]; then
+if [ -z "${TS_TUNE_NUM_CPUS:-}" ]; then
     # See if we can get the container's available CPUs from the cgroups metadata
     if [ -f /sys/fs/cgroup/cpuset/cpuset.cpus ]; then
         TS_TUNE_NUM_CPUS=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
@@ -63,12 +63,12 @@ if [ -z "${TS_TUNE_NUM_CPUS}" ]; then
     fi
 fi
 
-if [ ! -z "${TS_TUNE_MEMORY}" ]; then
+if [ ! -z "${TS_TUNE_MEMORY:-}" ]; then
     TS_TUNE_MEMORY_FLAGS=--memory="${TS_TUNE_MEMORY}"
 fi
 
-if [ ! -z "${TS_TUNE_NUM_CPUS}" ]; then
+if [ ! -z "${TS_TUNE_NUM_CPUS:-}" ]; then
     TS_TUNE_NUM_CPUS_FLAGS=--cpus=${TS_TUNE_NUM_CPUS}
 fi
 
-/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${PGDATA}/postgresql.conf" ${TS_TUNE_MEMORY_FLAGS} ${TS_TUNE_NUM_CPUS_FLAGS}
+/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${POSTGRESQL_CONF_DIR}/postgresql.conf" ${TS_TUNE_MEMORY_FLAGS} ${TS_TUNE_NUM_CPUS_FLAGS}


### PR DESCRIPTION
The previous images did not provide the correct POSTGRESQL_DATA_DIR environment variable, causing the Timescale init scripts to fail.

Fixes #50, fixes #56.