### PR TITLE
Update Dockerfiles to use explicit Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG PG_VERSION
 ############################
 # Build tools binaries in separate image
 ############################
-FROM golang:alpine AS tools
+ARG GO_VERSION=1.12.5
+FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.6.0
 
@@ -79,7 +80,7 @@ RUN \
     rm -f $(pg_config --sharedir)/extension/timescaledb--*--*.sql \
     && rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
     # Remove all but the last several versiosn ()
-    && KEEP_NUM_VERSIONS=8   # This number should be reduced to 5 eventually \
+    && KEEP_NUM_VERSIONS=7   # This number should be reduced to 5 eventually \
     && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-*.so | head -n -${KEEP_NUM_VERSIONS}) \
     && rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb-*.sql | head -n -${KEEP_NUM_VERSIONS}) \
     # Clean up the rest of the image

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -57,8 +57,6 @@ RUN set -ex \
 #####
 # Add the latest previous version to the end of the list for each new build
 #####
-RUN OLD_VERSION=1.0.0 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.0.1 /build/timescaledb/build_old.sh
 RUN OLD_VERSION=1.1.0 /build/timescaledb/build_old.sh
 RUN OLD_VERSION=1.1.1 /build/timescaledb/build_old.sh
 RUN OLD_VERSION=1.2.0 /build/timescaledb/build_old.sh
@@ -72,7 +70,7 @@ RUN \
     && rm -f $(pg_config --sharedir)/extension/timescaledb--*--*.sql \
     && rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
     # Remove all but the last several versiosn ()
-    && KEEP_NUM_VERSIONS=5   # This number should be reduced to 5 eventually \
+    && KEEP_NUM_VERSIONS=5 \
     && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-*.so | head -n -${KEEP_NUM_VERSIONS}) \
     && rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb-*.sql | head -n -${KEEP_NUM_VERSIONS}) \
     # Clean up the rest of the image


### PR DESCRIPTION
Using the most up-to-date version of Go is important so that our
tools don't have any security issues. By making the Go version an
argument to base image, we can ensure we are not using cached older
versions.

Also this cleans up some other bits of the Dockerfiles, including
reducing the number of older images stored in our main image.