### PR TITLE
Simplify Dockerfiles by removing latest tag logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=timescaledb
 ORG=timescale
-PG_VER=pg10
+PG_VER=pg11
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
 
@@ -13,9 +13,6 @@ default: image
 
 .build_$(VERSION)_$(PG_VER): Dockerfile
 	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
-ifeq ($(PG_VER),pg9.6)
-	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):latest
-endif
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	touch .build_$(VERSION)_$(PG_VER)
 
@@ -26,9 +23,6 @@ oss: .build_$(VERSION)_$(PG_VER)_oss
 push: image
 	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	docker push $(ORG)/$(NAME):latest-$(PG_VER)
-ifeq ($(PG_VER),pg9.6)
-	docker push $(ORG)/$(NAME):latest
-endif
 
 push-oss: oss
 	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-oss

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -2,7 +2,8 @@ ARG PG_VERSION
 ############################
 # Build tools binaries in separate image
 ############################
-FROM golang:alpine AS tools
+ARG GO_VERSION=1.12.5
+FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.6.0
 

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -1,19 +1,13 @@
 NAME=timescaledb
 ORG=timescale
-PG_VER=pg10
+PG_VER=pg11
+PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
 
 default: image
 
 .build_$(VERSION)_$(PG_VER): Dockerfile
-ifeq ($(PG_VER),pg9.6)
-	docker build -f ./Dockerfile --build-arg PG_VERSION=9.6.13 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
-	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-bitnami $(ORG)/$(NAME):latest-bitnami
-else ifeq ($(PG_VER),pg10)
-	docker build -f ./Dockerfile --build-arg PG_VERSION=10.8.0 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
-else
-	docker build -f ./Dockerfile --build-arg PG_VERSION=11.3.0 -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
-endif
+	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-bitnami $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-bitnami
 	touch .build_$(VERSION)_$(PG_VER)-bitnami
 

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -1,17 +1,12 @@
 NAME=timescaledb-postgis
 ORG=timescale
-PG_VER=pg10
+PG_VER=pg11
 VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile | sed "s/\(.*\)-.*/\1/")
 
 default: image
 
 .build_postgis_$(VERSION)_$(PG_VER): Dockerfile
-ifeq ($(PG_VER),pg9.6)
-	docker build --build-arg POSTGIS_VERSION=2.5.1 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
-	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):latest
-else
-	docker build --build-arg POSTGIS_VERSION=2.5.1 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
-endif
+	docker build --build-arg POSTGIS_VERSION=2.5.2 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	touch .build_postgis_$(VERSION)_$(PG_VER)
 
@@ -20,9 +15,6 @@ image: .build_postgis_$(VERSION)_$(PG_VER)
 push: image
 	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	docker push $(ORG)/$(NAME):latest-$(PG_VER)
-ifeq ($(PG_VER),pg9.6)
-	docker push $(ORG)/$(NAME):latest
-endif
 
 
 clean:


### PR DESCRIPTION
We are no longer supporting 'latest` tags in our repos because it
is hard to get the semantics correct. Without those tags, the logic
for the Makefiles also becomes simpler, since those specific cases
can now be combined with the general case.