### PR TITLE
Explicitly use PG_MAJOR if it is set

### DIFF
--- a/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
+++ b/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
@@ -71,4 +71,8 @@ if [ ! -z "${TS_TUNE_NUM_CPUS:-}" ]; then
     TS_TUNE_NUM_CPUS_FLAGS=--cpus=${TS_TUNE_NUM_CPUS}
 fi
 
-/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${POSTGRESQL_CONF_DIR}/postgresql.conf" ${TS_TUNE_MEMORY_FLAGS} ${TS_TUNE_NUM_CPUS_FLAGS}
+if [ ! -z "${PG_MAJOR}" ]; then
+    TS_TUNE_PG_VERSION=--pg-version=${PG_MAJOR}
+fi
+
+/usr/local/bin/timescaledb-tune --quiet --yes --conf-path="${POSTGRESQL_CONF_DIR}/postgresql.conf" ${TS_TUNE_MEMORY_FLAGS} ${TS_TUNE_NUM_CPUS_FLAGS} ${TS_TUNE_PG_VERSION}


### PR DESCRIPTION
On a recent Debian installation I ran into the issue that pg_config was
PostgreSQL 12, whereas only PostgreSQL 11 server binaries and libraries
were installed.

By passing on PG_MAJOR as --pg-version, we ensure that timescaledb-tune
will always use the correct version to make its decisions.

Currently, when building a Docker image for PostgreSQL 11 and installing
postgresql-common, timescaledb-tune fails as 12 is not (yet) supported
by timescaledb-tune.