### PR TITLE
Install TimescaleDB as a superuser

### DIFF
--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -2,10 +2,6 @@
 
 # Checks to support bitnami image with same scripts so they stay in sync
 if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
-	if [ -z "${POSTGRES_USER:-}" ]; then
-		POSTGRES_USER=${POSTGRESQL_USERNAME}
-	fi
-
 	if [ -z "${POSTGRES_DB:-}" ]; then
 		POSTGRES_DB=${POSTGRESQL_DATABASE}
 	fi
@@ -27,9 +23,9 @@ fi
 echo "timescaledb.telemetry_level=${TS_TELEMETRY}" >> ${POSTGRESQL_CONF_DIR}/postgresql.conf
 
 # create extension timescaledb in initial databases
-psql -U "${POSTGRES_USER}" postgres -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
-psql -U "${POSTGRES_USER}" template1 -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+psql postgres -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+psql template1 -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
 
 if [ "${POSTGRES_DB:-postgres}" != 'postgres' ]; then
-  psql -U "${POSTGRES_USER}" "${POSTGRES_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+  psql "${POSTGRES_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
 fi


### PR DESCRIPTION
The POSTGRESQL_USER that is used by Bitnami is a regular user and does
not have permissions to install TimescaleDB.

Therefore, we should execute psql without specifying a username, which
means we will connect as superuser to install the extension in the
relevant databases.

Fixes issue #79