### PR TITLE
Release 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG PG_VERSION
+ARG PREV_TS_VERSION=1.5.0
+ARG PREV_EXTRA
 ############################
 # Build tools binaries in separate image
 ############################
-ARG GO_VERSION=1.12.12
+ARG GO_VERSION=1.12.13
 FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.7.0
@@ -24,63 +26,16 @@ RUN apk update && apk add --no-cache git \
     && go build -o /go/bin/timescaledb-parallel-copy
 
 ############################
-# Build old versions in a separate stage
+# Grab old versions from previous version
 ############################
 ARG PG_VERSION
-FROM postgres:${PG_VERSION}-alpine AS oldversions
-ARG PG_VERSION
-ARG OSS_ONLY
-RUN set -ex \
-    && apk add --no-cache --virtual .fetch-deps \
-                ca-certificates \
-                git \
-                openssl \
-                openssl-dev \
-                tar \
-    && mkdir -p /build/ \
-    && git clone https://github.com/timescale/timescaledb /build/timescaledb \
-    \
-    && apk add --no-cache --virtual .build-deps \
-                coreutils \
-                dpkg-dev dpkg \
-                gcc \
-                libc-dev \
-                make \
-                cmake \
-                util-linux-dev \
-    \
-    && cd /build/timescaledb \
-    # This script is a bit ugly, but once all the old versions are buildable
-    # on PG11, we can remove the 'if' guard
-    && echo "if [ \"$(echo ${PG_VERSION} | cut -c1-2)\" != \"11\" ] || [ "\${OLD_VERSION}" \> "1.0.1" ]; then cd /build/timescaledb && rm -fr build && git reset HEAD --hard && git fetch && git checkout \${OLD_VERSION} && ./bootstrap -DPROJECT_INSTALL_METHOD=\"docker\"${OSS_ONLY} && cd build && make install; fi" > ./build_old.sh \
-    && chmod +x ./build_old.sh
-
-#####
-# Add the latest previous version to the end of the list for each new build
-#####
-RUN OLD_VERSION=1.1.1 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.2.0 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.2.1 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.2.2 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.3.0 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.3.1 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.3.2 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.4.0 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.4.1 /build/timescaledb/build_old.sh
-
-# Cleanup
-RUN \
-    # Remove update files and mock files; not needed for old versions
-    rm -f $(pg_config --sharedir)/extension/timescaledb--*--*.sql \
+FROM timescale/timescaledb:${PREV_TS_VERSION}-pg${PG_VERSION}${PREV_EXTRA} AS oldversions
+# Remove update files, mock files, and all but the last 5 .so/.sql files
+RUN rm -f $(pg_config --sharedir)/extension/timescaledb--*--*.sql \
     && rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
-    # Remove all but the last several versiosn ()
-    && KEEP_NUM_VERSIONS=6   # This number should be reduced to 5 eventually \
-    && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-*.so | head -n -${KEEP_NUM_VERSIONS}) \
-    && rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb-*.sql | head -n -${KEEP_NUM_VERSIONS}) \
-    # Clean up the rest of the image
-    && cd ~ \
-    && apk del .fetch-deps .build-deps \
-    && rm -rf /build \
+    && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-tsl-*.so | head -n -5) \
+    && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-1*.so | head -n -5) \
+    && rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb-*.sql | head -n -5)
 
 ############################
 # Now build image and copy in tools
@@ -92,7 +47,7 @@ ARG OSS_ONLY
 MAINTAINER Timescale https://www.timescale.com
 
 # Update list above to include previous versions when changing this
-ENV TIMESCALEDB_VERSION 1.4.2
+ENV TIMESCALEDB_VERSION 1.5.1
 
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/
@@ -121,10 +76,11 @@ RUN set -ex \
     # Build current version \
     && cd /build/timescaledb && rm -fr build \
     && git checkout ${TIMESCALEDB_VERSION} \
-    && ./bootstrap -DPROJECT_INSTALL_METHOD="docker"${OSS_ONLY} \
+    && ./bootstrap -DREGRESS_CHECKS=OFF -DPROJECT_INSTALL_METHOD="docker"${OSS_ONLY} \
     && cd build && make install \
     && cd ~ \
     \
+    && if [ "${OSS_ONLY}" != "" ]; then rm -f $(pg_config --pkglibdir)/timescaledb-tsl-*.so; fi \
     && apk del .fetch-deps .build-deps \
     && rm -rf /build \
     && sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /usr/local/share/postgresql/postgresql.conf.sample

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
 default: image
 
 .build_$(VERSION)_$(PG_VER)_oss: Dockerfile
-	docker build --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER)-oss .
+	docker build --build-arg PREV_EXTRA="-oss" --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER)-oss .
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-oss $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-oss
 	touch .build_$(VERSION)_$(PG_VER)_oss
 

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -1,8 +1,9 @@
 ARG PG_VERSION
+ARG PREV_TS_VERSION=1.5.0
 ############################
 # Build tools binaries in separate image
 ############################
-ARG GO_VERSION=1.12.12
+ARG GO_VERSION=1.12.13
 FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.7.0
@@ -24,75 +25,17 @@ RUN apk update && apk add --no-cache git \
     && go build -o /go/bin/timescaledb-parallel-copy
 
 ############################
-# Build old versions in a separate stage
+# Grab old versions from previous version
 ############################
 ARG PG_VERSION
-FROM bitnami/postgresql:${PG_VERSION} AS oldversions
-ARG PG_VERSION
-
+FROM timescale/timescaledb:${PREV_TS_VERSION}-pg${PG_VERSION}-bitnami AS oldversions
+# Remove update files, mock files, and all but the last 5 .so/.sql files
 USER 0
-RUN set -ex \
-    && mkdir -p /var/lib/apt/lists/partial \
-    && apt-get update \
-    && apt-get -y install \
-            \
-            build-essential \
-            libssl-dev \
-            git \
-            \
-            dpkg-dev \
-            gcc \
-            libc-dev \
-            make \
-            cmake \
-            wget \
-    && mkdir -p /build/ \
-    && git clone https://github.com/timescale/timescaledb /build/timescaledb \
-    \
-    && cd /build/timescaledb \
-    # This script is a bit ugly, but once all the old versions are buildable
-    # on PG11, we can remove the 'if' guard
-    && echo "if [ \"$(echo ${PG_VERSION} | cut -c1-2)\" != \"11\" ] || [ "\${OLD_VERSION}" \> "1.0.1" ]; then cd /build/timescaledb && rm -fr build && git reset HEAD --hard && git fetch && git checkout \${OLD_VERSION} && ./bootstrap -DPROJECT_INSTALL_METHOD=\"docker\" && cd build && make install; fi" > ./build_old.sh \
-    && chmod +x ./build_old.sh
-
-#####
-# Add the latest previous version to the end of the list for each new build
-#####
-RUN OLD_VERSION=1.2.2 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.3.0 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.3.1 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.3.2 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.4.0 /build/timescaledb/build_old.sh
-RUN OLD_VERSION=1.4.1 /build/timescaledb/build_old.sh
-
-# Cleanup
-RUN \
-    # Remove update files and mock files; not needed for old versions
-    echo $(pg_config --pkglibdir) \
-    && rm -f $(pg_config --sharedir)/extension/timescaledb--*--*.sql \
+RUN rm -f $(pg_config --sharedir)/extension/timescaledb--*--*.sql \
     && rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
-    # Remove all but the last several versiosn ()
-    && KEEP_NUM_VERSIONS=5 \
-    && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-*.so | head -n -${KEEP_NUM_VERSIONS}) \
-    && rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb-*.sql | head -n -${KEEP_NUM_VERSIONS}) \
-    # Clean up the rest of the image
-    && cd ~ \
-    && apt-get autoremove --purge -y \
-            \
-            build-essential \
-            libssl-dev \
-            \
-            dpkg-dev \
-            gcc \
-            libc-dev \
-            make \
-            cmake \
-    && apt-get clean -y \
-    && rm -rf \
-      "${HOME}/.cache" \
-        /var/lib/apt/lists/* \
-        /tmp/*               \
-        /var/tmp/*
+    && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-tsl-*.so | head -n -5) \
+    && rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-1*.so | head -n -5) \
+    && rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb-*.sql | head -n -5)
 
 ############################
 # Now build image and copy in tools
@@ -103,12 +46,13 @@ ARG PG_VERSION
 
 MAINTAINER Timescale https://www.timescale.com
 
-ENV TIMESCALEDB_VERSION 1.4.2
+# Update list above to include previous versions when changing this
+ENV TIMESCALEDB_VERSION 1.5.1
 
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/
-COPY --from=oldversions /opt/bitnami/postgresql/lib/timescaledb-*.so /usr/local/lib/postgresql/
-COPY --from=oldversions /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /usr/local/share/postgresql/extension/
+COPY --from=oldversions /opt/bitnami/postgresql/lib/timescaledb-*.so /opt/bitnami/postgresql/lib/
+COPY --from=oldversions /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /opt/bitnami/postgresql/share/extension/
 
 USER 0
 RUN set -ex \
@@ -132,7 +76,7 @@ RUN set -ex \
     # Build current version \
     && cd /build/timescaledb && rm -fr build \
     && git checkout ${TIMESCALEDB_VERSION} \
-    && ./bootstrap -DPROJECT_INSTALL_METHOD="docker" \
+    && ./bootstrap -DREGRESS_CHECKS=OFF -DPROJECT_INSTALL_METHOD="docker-bitnami" \
     && cd build && make install \
     && cd ~ \
     \


### PR DESCRIPTION
This also vastly simplifies the build process for alpine and bitnami
by simply extracting the old versions from the previous Docker image
instead of building the old versions for each new one.