### PR TITLE
Fix PostGIS builds

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -3,7 +3,7 @@ FROM timescale/timescaledb:1.6.0-${PG_VERSION_TAG}
 
 MAINTAINER Timescale https://www.timescale.com
 ARG POSTGIS_VERSION
-ENV POSTGIS_VERSION ${POSTGIS_VERSION:-2.5.2}
+ENV POSTGIS_VERSION ${POSTGIS_VERSION:-2.5.3}
 
 RUN set -ex \
     && apk add --no-cache --virtual .fetch-deps \
@@ -11,31 +11,37 @@ RUN set -ex \
                 openssl \
                 tar \
     # add libcrypto from (edge:main) for gdal-2.3.0
-    && apk add --no-cache --virtual .crypto-rundeps \
-                --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-                libressl2.7-libcrypto \
-                libcrypto1.1 \
-    && apk add --no-cache --virtual .postgis-deps --repository http://nl.alpinelinux.org/alpine/edge/testing \
-        geos \
-        gdal \
-        proj \
-        protobuf-c \
-    && apk add --no-cache --virtual .build-deps --repository http://nl.alpinelinux.org/alpine/edge/testing \
-        postgresql-dev \
-        perl \
+    #&& apk add --no-cache --virtual .crypto-rundeps \
+    #            --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    #            libressl2.7-libcrypto \
+    #            libcrypto1.1 \
+    #            poppler \
+    #            llvm9-dev \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
         file \
-        geos-dev \
+        json-c-dev \
+        libtool \
         libxml2-dev \
+        make \
+        perl \
+        llvm \
+        clang \
+        clang-dev \
+    && apk add --no-cache --virtual .build-deps-edge \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        g++ \
         gdal-dev \
+        geos-dev \
         proj-dev \
         protobuf-c-dev \
-        json-c-dev \
-        gcc g++ \
-        make \
     && cd /tmp \
-    && wget http://download.osgeo.org/postgis/source/postgis-${POSTGIS_VERSION}.tar.gz -O - | tar -xz \
+    && wget https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz -O - | tar -xz \
     && chown root:root -R postgis-${POSTGIS_VERSION} \
     && cd /tmp/postgis-${POSTGIS_VERSION} \
+    && ./autogen.sh \
     && ./configure \
     && echo "PERL = /usr/bin/perl" >> extensions/postgis/Makefile \
     && echo "PERL = /usr/bin/perl" >> extensions/postgis_topology/Makefile \
@@ -43,7 +49,14 @@ RUN set -ex \
     && make -s install \
     && apk add --no-cache --virtual .postgis-rundeps \
         json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-edge \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        geos \
+        gdal \
+        proj \
+        protobuf-c \
+        libstdc++ \
     && cd / \
-    \
     && rm -rf /tmp/postgis-${POSTGIS_VERSION} \
-    && apk del .fetch-deps .build-deps
+    && apk del .fetch-deps .build-deps .build-deps-edge

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -6,7 +6,7 @@ VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile | sed "s/\(.*\)-.*
 default: image
 
 .build_postgis_$(VERSION)_$(PG_VER): Dockerfile
-	docker build --build-arg POSTGIS_VERSION=2.5.2 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
+	docker build --build-arg POSTGIS_VERSION=2.5.3 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
 	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 	touch .build_postgis_$(VERSION)_$(PG_VER)
 


### PR DESCRIPTION
The previous Dockerfile for PostGIS builds would fail when trying
to use libgeos. Using a Dockerfile from the official postgis repos
helped resolves the issue and upgrades us to PostGIS 3.0.0.

New Dockerfile based on the one found here:
https://github.com/postgis/docker-postgis/issues/157#issuecomment-562812857