### PR TITLE
Build multi-platform docker image of TimescaleDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,25 @@ ORG=timescale
 PG_VER=pg11
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
+PLATFORM=linux/amd64,linux/arm/v7,linux/arm/v6,linux/386,linux/arm64
 
 default: image
+
+.multi_$(VERSION)_$(PG_VER)_oss: Dockerfile
+	docker buildx create --name multibuild --use
+	docker buildx inspect multibuild --bootstrap
+	docker buildx build --platform $(PLATFORM) --build-arg PREV_EXTRA="-oss" --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) \
+		-t $(ORG)/$(NAME):latest-$(PG_VER)-oss -t $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-oss --push .
+	touch .multi_$(VERSION)_$(PG_VER)_oss
+	docker buildx rm multibuild
+
+.multi_$(VERSION)_$(PG_VER): Dockerfile
+	docker buildx create --name multibuild --use
+	docker buildx inspect multibuild --bootstrap
+	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION=$(PG_VER_NUMBER) \
+		-t $(ORG)/$(NAME):latest-$(PG_VER) -t $(ORG)/$(NAME):$(VERSION)-$(PG_VER) --push .
+	touch .multi_$(VERSION)_$(PG_VER)
+	docker buildx rm multibuild
 
 .build_$(VERSION)_$(PG_VER)_oss: Dockerfile
 	docker build --build-arg PREV_EXTRA="-oss" --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER)-oss .
@@ -28,7 +45,12 @@ push-oss: oss
 	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-oss
 	docker push $(ORG)/$(NAME):latest-$(PG_VER)-oss
 
-clean:
-	rm -f *~ .build_*
+multi: .multi_$(VERSION)_$(PG_VER)
 
-.PHONY: default image push push-oss oss clean
+multi-oss: .multi_$(VERSION)_$(PG_VER)_oss
+
+clean:
+	rm -f *~ .build_* .multi_*
+	docker buildx rm multibuild
+
+.PHONY: default image push push-oss oss multi multi-oss clean


### PR DESCRIPTION
Adds builds to create multi-platform docker images of TimescaleDB,
which are pushed into Timescale docker-hub.