### PR TITLE
Skip the initdb scripts in slave mode

### DIFF
--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -2,6 +2,15 @@
 
 # Checks to support bitnami image with same scripts so they stay in sync
 if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
+	if [ -z "${POSTGRES_REPLICATION_MODE:-}" ]; then
+		POSTGRES_REPLICATION_MODE=${POSTGRESQL_REPLICATION_MODE}
+	fi
+
+	if [ "${POSTGRES_REPLICATION_MODE:-}" == "slave" ]; then
+		echo "exit $0 in slave mode"
+		exit 0
+	fi
+
 	if [ -z "${POSTGRES_USER:-}" ]; then
 		POSTGRES_USER=${POSTGRESQL_USERNAME}
 	fi

--- a/docker-entrypoint-initdb.d/001_reenable_auth.sh
+++ b/docker-entrypoint-initdb.d/001_reenable_auth.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
+	if [ -z "${POSTGRES_REPLICATION_MODE:-}" ]; then
+		POSTGRES_REPLICATION_MODE=${POSTGRESQL_REPLICATION_MODE}
+	fi
+
+	if [ "${POSTGRES_REPLICATION_MODE:-}" == "slave" ]; then
+		echo "exit $0 in slave mode"
+		exit 0
+	fi
+fi
+
+
+
 if [ -z "${POSTGRESQL_CONF_DIR:-}" ]; then
         POSTGRESQL_CONF_DIR=${PGDATA}
 fi

--- a/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
+++ b/docker-entrypoint-initdb.d/002_timescaledb_tune.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
+	if [ -z "${POSTGRES_REPLICATION_MODE:-}" ]; then
+		POSTGRES_REPLICATION_MODE=${POSTGRESQL_REPLICATION_MODE}
+	fi
+
+	if [ "${POSTGRES_REPLICATION_MODE:-}" == "slave" ]; then
+		echo "exit $0 in slave mode"
+		exit 0
+	fi
+fi
+
+
 NO_TS_TUNE=${NO_TS_TUNE:-""}
 TS_TUNE_MEMORY=${TS_TUNE_MEMORY:-""}
 TS_TUNE_NUM_CPUS=${TS_TUNE_NUM_CPUS:-""}


### PR DESCRIPTION
It's not reasonable to run initdb scripts on the slave mode.
Skip these script, so I can use the official Bitnami Postgresql
helm chart to install a full cluster.