### PR TITLE
Automate builds in GitHub Actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,83 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master, dev-build ]
+
+env:
+  ORG: timescale # timescaledev
+  
+jobs:
+
+  # Build multi-arch TimescaleDB images for both TSL and OSS code.
+  timescaledb:
+
+    name: PG${{ matrix.pg }}${{ matrix.oss }}
+    runs-on: ubuntu-latest
+    strategy: 
+      matrix:
+        pg: [ 9.6, 10, 11, 12 ]
+        oss: [ "", "-oss" ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: crazy-max/ghaction-docker-buildx@v2
+      with:
+        buildx-version: latest
+        skip-cache: false
+        qemu-version: latest
+
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+
+    - name: Build and push multi-platform Docker image for TimescaleDB
+      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
+
+  # Build bitnami images of TimscaleDB. 
+  # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
+  # The images are only built for TSL code.
+  timescaledb-bitnami:
+
+    name: PG${{ matrix.pg }}-bitnami
+    runs-on: ubuntu-latest
+    strategy: 
+      matrix:
+        pg: [ 9.6, 10, 11, 12 ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+
+    - name: Build and push amd64 Docker image for TimescaleDB bitnami
+      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      working-directory: bitnami
+
+  # Builds image, which extends TimescaleDB image with PostGIS. Thus it depends on the job timescaledb.
+  # The images are built only for amd64. Support for 32-bit needs to be investigated.
+  # The images are built on top of TSL version only.
+  timescaledb-postgis:
+
+    name: PG${{ matrix.pg }}-postgis
+    runs-on: ubuntu-latest
+    needs: timescaledb
+    strategy: 
+      matrix:
+        pg: [ 9.6, 10, 11, 12 ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+
+    - name: Build and push amd64 Docker image for TimescaleDB bitnami
+      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      working-directory: postgis

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG PG_VERSION
 FROM postgres:${PG_VERSION}-alpine
 ARG OSS_ONLY
 
-MAINTAINER Timescale https://www.timescale.com
+LABEL maintainer="Timescale https://www.timescale.com"
 
 # Update list above to include previous versions when changing this
 ENV TIMESCALEDB_VERSION 1.7.1

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -44,7 +44,7 @@ ARG PG_VERSION
 FROM bitnami/postgresql:${PG_VERSION}
 ARG PG_VERSION
 
-MAINTAINER Timescale https://www.timescale.com
+LABEL maintainer="Timescale https://www.timescale.com"
 
 # Update list above to include previous versions when changing this
 ENV TIMESCALEDB_VERSION 1.7.1

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -1,5 +1,7 @@
 NAME=timescaledb
-ORG=timescale
+# Default is to timescaledev to avoid unexpected push to the main repo
+# Set ORG to timescale in the caller
+ORG=timescaledev
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -1,7 +1,7 @@
 ARG PG_VERSION_TAG
 FROM timescale/timescaledb:1.7.1-${PG_VERSION_TAG}
 
-MAINTAINER Timescale https://www.timescale.com
+LABEL maintainer="Timescale https://www.timescale.com"
 ARG POSTGIS_VERSION
 ENV POSTGIS_VERSION ${POSTGIS_VERSION:-2.5.3}
 

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -1,5 +1,7 @@
 NAME=timescaledb-postgis
-ORG=timescale
+# Default is to timescaledev to avoid unexpected push to the main repo
+# Set ORG to timescale in the caller
+ORG=timescaledev
 PG_VER=pg12
 VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile | sed "s/\(.*\)-.*/\1/")
 


### PR DESCRIPTION
Adds GitHub Actions workflow to build docker images on push to master
or to dev-build. It reuses existing Dockerfile and Makefile with minor
modifications. I replaces deprecated MAINTAINER with using LABEL.

Fixes #22

Part of https://github.com/timescale/timescaledb-private/issues/752
Closes https://github.com/timescale/timescaledb-private/issues/741
