### PR TITLE
Update version of GH Actions for buildx

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,11 +24,9 @@ jobs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v2
+      uses: crazy-max/ghaction-docker-buildx@v2.0.0
       with:
-        buildx-version: latest
         skip-cache: false
-        qemu-version: latest
 
     - name: Available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
@@ -45,6 +43,7 @@ jobs:
   timescaledb-bitnami:
 
     name: PG${{ matrix.pg }}-bitnami
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     strategy: 
       matrix:


### PR DESCRIPTION
This commit sets exact version of crazy-max/ghaction-docker-buildx to
v.2.0.0, which is known to work. The later versions are failing to
build the images. This commit is still applied to all 4 PG versions to
rebuild multi-arch images.

Since bitnami is build for single architecture, it is excluded from pull_request 
test builds.

Successful test: https://github.com/timescale/timescaledb-docker/actions/runs/128365692