### PR TITLE
Release 2.0.0-beta5 with script generalisation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,9 +3,10 @@ name: Docker Image CI
 on:
   push:
     branches: [ master, dev-build ]
+  pull_request:
 
 env:
-  ORG: timescale # timescaledev
+  ORG: timescaledev # timescaledev
   
 jobs:
 
@@ -16,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix:
-        pg: [ 9.6, 10, 11, 12 ]
+        pg: [ 11, 12 ]
         oss: [ "", "-oss" ]
 
     steps:
@@ -46,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix:
-        pg: [ 9.6, 10, 11, 12 ]
+        pg: [ 11, 12 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -68,7 +69,7 @@ jobs:
     needs: timescaledb
     strategy: 
       matrix:
-        pg: [ 9.6, 10, 11, 12 ]
+        pg: [ 11, 12 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,7 +43,6 @@ jobs:
   timescaledb-bitnami:
 
     name: PG${{ matrix.pg }}-bitnami
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     strategy: 
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PREV_TS_VERSION=1.7.0
+ARG PREV_TS_VERSION=1.7.1
 ARG PREV_EXTRA
 ############################
 # Build tools binaries in separate image
@@ -47,7 +47,7 @@ ARG OSS_ONLY
 LABEL maintainer="Timescale https://www.timescale.com"
 
 # Update list above to include previous versions when changing this
-ENV TIMESCALEDB_VERSION 1.7.1
+ENV TIMESCALEDB_VERSION 2.0.0-beta5
 
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_VERSION
-ARG PREV_TS_VERSION=1.7.0
+ARG PREV_TS_VERSION=1.7.1
 ############################
 # Build tools binaries in separate image
 ############################
@@ -47,7 +47,7 @@ ARG PG_VERSION
 LABEL maintainer="Timescale https://www.timescale.com"
 
 # Update list above to include previous versions when changing this
-ENV TIMESCALEDB_VERSION 1.7.1
+ENV TIMESCALEDB_VERSION 2.0.0-beta5
 
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -5,19 +5,25 @@ ORG=timescaledev
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
+# Beta releases should not be tagged as latest, so BETA is used to track.
+BETA=$(findstring beta,$(VERSION))
+TAG_VERSION=$(ORG)/$(NAME):$(VERSION)-$(PG_VER)-bitnami
+TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)-bitnami
+TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 
 default: image
 
 .build_$(VERSION)_$(PG_VER): Dockerfile
-	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) -t $(ORG)/$(NAME):latest-$(PG_VER)-bitnami ..
-	docker tag $(ORG)/$(NAME):latest-$(PG_VER)-bitnami $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-bitnami
+	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) $(TAG) ..
 	touch .build_$(VERSION)_$(PG_VER)-bitnami
 
 image: .build_$(VERSION)_$(PG_VER)
 
 push: image
-	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)-bitnami
-	docker push $(ORG)/$(NAME):latest-$(PG_VER)-bitnami
+	docker push $(TAG_VERSION)
+	ifndef $(BETA)
+		docker push $(TAG_LATEST)
+	endif
 
 clean:
 	rm -f *~ .build_*

--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_VERSION_TAG
-FROM timescale/timescaledb:1.7.1-${PG_VERSION_TAG}
+FROM timescale/timescaledb:2.0.0-beta5-${PG_VERSION_TAG}
 
 LABEL maintainer="Timescale https://www.timescale.com"
 ARG POSTGIS_VERSION

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -4,19 +4,25 @@ NAME=timescaledb-postgis
 ORG=timescaledev
 PG_VER=pg12
 VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile | sed "s/\(.*\)-.*/\1/")
+# Beta releases should not be tagged as latest, so BETA is used to track.
+BETA=$(findstring beta,$(VERSION))
+TAG_VERSION=$(ORG)/$(NAME):$(VERSION)-$(PG_VER)
+TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)
+TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 
 default: image
 
 .build_postgis_$(VERSION)_$(PG_VER): Dockerfile
-	docker build --build-arg POSTGIS_VERSION=2.5.3 --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORG)/$(NAME):latest-$(PG_VER) .
-	docker tag $(ORG)/$(NAME):latest-$(PG_VER) $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
+	docker build --build-arg POSTGIS_VERSION=2.5.3 --build-arg PG_VERSION_TAG=$(PG_VER) $(TAG) .
 	touch .build_postgis_$(VERSION)_$(PG_VER)
 
 image: .build_postgis_$(VERSION)_$(PG_VER)
 
 push: image
-	docker push $(ORG)/$(NAME):$(VERSION)-$(PG_VER)
-	docker push $(ORG)/$(NAME):latest-$(PG_VER)
+	docker push $(TAG_VERSION)
+	ifndef $(BETA)
+		docker push $(TAG_LATEST)
+	endif
 
 
 clean:


### PR DESCRIPTION
Includes 2 commits:

## Generalize make scripts to allow beta releases

Beta images should not be tagged as latest. This commit generalizes
the make scripts to exclude latest tag on betas, but allows to tag
usual releases with latest.

## Release 2.0.0-beta5