### PR TITLE
Delete Telemetry job when telemetry is disabled

### DIFF
--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+create_sql=`mktemp`
+
 # Checks to support bitnami image with same scripts so they stay in sync
 if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
 	if [ -z "${POSTGRES_USER:-}" ]; then
@@ -19,17 +21,28 @@ if [ -z "${POSTGRESQL_CONF_DIR:-}" ]; then
 	POSTGRESQL_CONF_DIR=${PGDATA}
 fi
 
+cat <<EOF >${create_sql}
+CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+EOF
+
 TS_TELEMETRY='basic'
 if [ "${TIMESCALEDB_TELEMETRY:-}" == "off" ]; then
 	TS_TELEMETRY='off'
+
+	# We delete the job as well to ensure that we do not spam the
+	# log with other messages related to the Telemetry job.
+	cat <<EOF >>${create_sql}
+DELETE FROM _timescaledb_config.bgw_job WHERE job_type = 'telemetry_and_version_check_if_enabled';
+EOF
 fi
 
 echo "timescaledb.telemetry_level=${TS_TELEMETRY}" >> ${POSTGRESQL_CONF_DIR}/postgresql.conf
 
+
 # create extension timescaledb in initial databases
-psql -U "${POSTGRES_USER}" postgres -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
-psql -U "${POSTGRES_USER}" template1 -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+psql -U "${POSTGRES_USER}" postgres -f ${create_sql}
+psql -U "${POSTGRES_USER}" template1 -f ${create_sql}
 
 if [ "${POSTGRES_DB:-postgres}" != 'postgres' ]; then
-  psql -U "${POSTGRES_USER}" "${POSTGRES_DB}" -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+    psql -U "${POSTGRES_USER}" "${POSTGRES_DB}" -f ${create_sql}
 fi


### PR DESCRIPTION
If Telemetry is disabled by setting `TIMESCALEDB_TELEMETRY` to `off`,
the job is still present in the `bgw_job` table and will still be
processed as a job and generate errors and warnings even though it does
not do anything when executed.

This commit fixes this by deleting the Telemetry job during
configuration if the `TIMESCALEDB_TELEMETRY` is set to `off`.

Fixes timescale/timescaledb#1788