### PR TITLE
Remove trailing space in ORG default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=timescaledb
 # Default is to timescaledev to avoid unexpected push to the main repo
 # Set ORG to timescale in the caller
-ORG=timescaledev 
+ORG=timescaledev
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)


### PR DESCRIPTION
This causes `make' or `make image' fail by default because the tags
containing spaces.