### PR TITLE
Add timescaledb backup tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,13 @@ RUN apk update && apk add --no-cache git \
     && go get -d -v \
     && go build -o /go/bin/timescaledb-parallel-copy \
     # Build timescaledb-backup (ts_backup/ts_restore)
-    && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/cmd/ts-dump/ \
+    && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/ \
     && git fetch && git checkout --quiet $(git describe --abbrev=0) \
-    && go get -d -v \
     && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/cmd/ts-dump/ \
+    && go get -d -v \
     && go build -o /go/bin/ts-dump \
     && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/cmd/ts-restore/ \
+    && go get -d -v \
     && go build -o /go/bin/ts-restore
 
 ############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk update && apk add --no-cache git \
     && cd ${GOPATH}/src/github.com/timescale/ \
     && git clone https://github.com/timescale/timescaledb-tune.git \
     && git clone https://github.com/timescale/timescaledb-parallel-copy.git \
+    && git clone https://github.com/timescale/timescaledb-backup.git \
     # Build timescaledb-tune
     && cd timescaledb-tune/cmd/timescaledb-tune \
     && git fetch && git checkout --quiet $(git describe --abbrev=0) \
@@ -23,7 +24,15 @@ RUN apk update && apk add --no-cache git \
     && cd ${GOPATH}/src/github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy \
     && git fetch && git checkout --quiet $(git describe --abbrev=0) \
     && go get -d -v \
-    && go build -o /go/bin/timescaledb-parallel-copy
+    && go build -o /go/bin/timescaledb-parallel-copy \
+    # Build timescaledb-backup (ts_backup/ts_restore)
+    && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/cmd/ts-dump/ \
+    && git fetch && git checkout --quiet $(git describe --abbrev=0) \
+    && go get -d -v \
+    && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/cmd/ts-dump/ \
+    && go build -o /go/bin/ts-dump \
+    && cd ${GOPATH}/src/github.com/timescale/timescaledb-backup/cmd/ts-restore/ \
+    && go build -o /go/bin/ts-restore
 
 ############################
 # Grab old versions from previous version


### PR DESCRIPTION
Hello,

I have checked out **timescale/timescaledb-docker** to my local machine, and modified the build steps to include building the **timescale/timescaledb-backup** tools (ts-dump/ts-restore) into the 'tools' stage of the Docker build. This seems to build as expected for me, and a cursory test of these tools seems to work as expected.

Can someone take a look at this? What would we consider sufficient testing for this change. 

Thanks,
Joel