### PR TITLE
🛠 Multi-arch timescale-postgis build (ARM support)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -97,3 +97,4 @@ jobs:
 
     - name: Build and push multi-platform Docker image for TimescaleDB-postgis
       run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      working-directory: postgis

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,59 +9,59 @@ env:
 
 jobs:
 
-#  # Build multi-arch TimescaleDB images for both TSL and OSS code.
-#  timescaledb:
-#
-#    name: PG${{ matrix.pg }}${{ matrix.oss }}
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        pg: [ 11, 12, 13 ]
-#        oss: [ "", "-oss" ]
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Set up QEMU
-#      uses: docker/setup-qemu-action@v1
-#      with:
-#        platforms: all
-#
-#    - name: Set up Docker Buildx
-#      id: buildx
-#      uses: docker/setup-buildx-action@v1
-#
-#    - name: Available platforms
-#      run: echo ${{ steps.buildx.outputs.platforms }}
-#
-#    - name: Login to DockerHub Registry
-#      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-#
-#    - name: Build and push multi-platform Docker image for TimescaleDB
-#      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
-#
-#  # Build bitnami images of TimscaleDB.
-#  # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
-#  # The images are only built for TSL code.
-#  timescaledb-bitnami:
-#
-#    name: PG${{ matrix.pg }}-bitnami
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        pg: [ 11, 12, 13 ]
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Login to DockerHub Registry
-#      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-#
-#    - name: Build and push amd64 Docker image for TimescaleDB bitnami
-#      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
-#      working-directory: bitnami
+  # Build multi-arch TimescaleDB images for both TSL and OSS code.
+  timescaledb:
+
+    name: PG${{ matrix.pg }}${{ matrix.oss }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [ 11, 12, 13 ]
+        oss: [ "", "-oss" ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+
+    - name: Build and push multi-platform Docker image for TimescaleDB
+      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
+
+  # Build bitnami images of TimscaleDB.
+  # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
+  # The images are only built for TSL code.
+  timescaledb-bitnami:
+
+    name: PG${{ matrix.pg }}-bitnami
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [ 11, 12, 13 ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+
+    - name: Build and push amd64 Docker image for TimescaleDB bitnami
+      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      working-directory: bitnami
 
   # Builds image, which extends TimescaleDB image with PostGIS. Thus it depends on the job timescaledb.
   # The `amd` images are built only for amd64. Support for 32-bit needs to be investigated.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -71,7 +71,7 @@ jobs:
 
     name: PG${{ matrix.pg }}-postgis
     runs-on: ubuntu-latest
-#    needs: timescaledb
+    needs: timescaledb
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -97,4 +97,3 @@ jobs:
 
     - name: Build and push multi-platform Docker image for TimescaleDB-postgis
       run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
-      working-directory: postgis

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,59 +9,59 @@ env:
 
 jobs:
 
-  # Build multi-arch TimescaleDB images for both TSL and OSS code.
-  timescaledb:
-
-    name: PG${{ matrix.pg }}${{ matrix.oss }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        pg: [ 11, 12, 13 ]
-        oss: [ "", "-oss" ]
-
-    steps:
-    - uses: actions/checkout@v2
-      
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: all
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-
-    - name: Login to DockerHub Registry
-      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-
-    - name: Build and push multi-platform Docker image for TimescaleDB
-      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
-
-  # Build bitnami images of TimscaleDB.
-  # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
-  # The images are only built for TSL code.
-  timescaledb-bitnami:
-
-    name: PG${{ matrix.pg }}-bitnami
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        pg: [ 11, 12, 13 ]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Login to DockerHub Registry
-      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-
-    - name: Build and push amd64 Docker image for TimescaleDB bitnami
-      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
-      working-directory: bitnami
+#  # Build multi-arch TimescaleDB images for both TSL and OSS code.
+#  timescaledb:
+#
+#    name: PG${{ matrix.pg }}${{ matrix.oss }}
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        pg: [ 11, 12, 13 ]
+#        oss: [ "", "-oss" ]
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Set up QEMU
+#      uses: docker/setup-qemu-action@v1
+#      with:
+#        platforms: all
+#
+#    - name: Set up Docker Buildx
+#      id: buildx
+#      uses: docker/setup-buildx-action@v1
+#
+#    - name: Available platforms
+#      run: echo ${{ steps.buildx.outputs.platforms }}
+#
+#    - name: Login to DockerHub Registry
+#      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+#
+#    - name: Build and push multi-platform Docker image for TimescaleDB
+#      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
+#
+#  # Build bitnami images of TimscaleDB.
+#  # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
+#  # The images are only built for TSL code.
+#  timescaledb-bitnami:
+#
+#    name: PG${{ matrix.pg }}-bitnami
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        pg: [ 11, 12, 13 ]
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Login to DockerHub Registry
+#      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+#
+#    - name: Build and push amd64 Docker image for TimescaleDB bitnami
+#      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
+#      working-directory: bitnami
 
   # Builds image, which extends TimescaleDB image with PostGIS. Thus it depends on the job timescaledb.
   # The `amd` images are built only for amd64. Support for 32-bit needs to be investigated.
@@ -71,7 +71,7 @@ jobs:
 
     name: PG${{ matrix.pg }}-postgis
     runs-on: ubuntu-latest
-    needs: timescaledb
+#    needs: timescaledb
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -96,5 +96,5 @@ jobs:
       run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
     - name: Build and push multi-platform Docker image for TimescaleDB-postgis
-      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      run: make multi ORG=$ORG PG_VER=pg${{ matrix.pg }}
       working-directory: postgis

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -64,7 +64,8 @@ jobs:
       working-directory: bitnami
 
   # Builds image, which extends TimescaleDB image with PostGIS. Thus it depends on the job timescaledb.
-  # The images are built only for amd64. Support for 32-bit needs to be investigated.
+  # The `amd` images are built only for amd64. Support for 32-bit needs to be investigated.
+  # Uses same archs as base TimescaleDB images
   # The images are built on top of TSL version only.
   timescaledb-postgis:
 
@@ -79,9 +80,21 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
     - name: Login to DockerHub Registry
       run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
-    - name: Build and push amd64 Docker image for TimescaleDB bitnami
-      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
+    - name: Build and push multi-platform Docker image for TimescaleDB-postgis
+      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
       working-directory: postgis

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -20,7 +20,7 @@ default: image
 .multi_postgis_$(VERSION)_$(PG_VER): Dockerfile
 	docker buildx create --platform $(PLATFORM) --name multibuild --use
 	docker buildx inspect multibuild --bootstrap
-	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION_TAG=$(PG_VER_NUMBER) \
+	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION_TAG=$(PG_VER) \
 		--build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) $(TAG) $(PUSH_MUTLI) .
 	touch .multi_$(VERSION)_$(PG_VER)
 	docker buildx rm multibuild

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -3,14 +3,26 @@ NAME=timescaledb-postgis
 # Set ORG to timescale in the caller
 ORG=timescaledev
 PG_VER=pg12
+PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile | sed "s/\(.*\)-.*/\1/")
 # Beta releases should not be tagged as latest, so BETA is used to track.
 BETA=$(findstring rc,$(VERSION))
+PLATFORM=linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+# PUSH_MULTI can be set to nothing for dry-run without pushing during multi-arch build
+PUSH_MUTLI=--push
 TAG_VERSION=$(ORG)/$(NAME):$(VERSION)-$(PG_VER)
 TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)
 TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 
 default: image
+
+.multi_postgis_$(VERSION)_$(PG_VER): Dockerfile
+	docker buildx create --platform $(PLATFORM) --name multibuild --use
+	docker buildx inspect multibuild --bootstrap
+	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION=$(PG_VER_NUMBER) \
+		$(TAG) $(PUSH_MUTLI) .
+	touch .multi_$(VERSION)_$(PG_VER)
+	docker buildx rm multibuild
 
 .build_postgis_$(VERSION)_$(PG_VER): Dockerfile
 	docker build --build-arg POSTGIS_VERSION=2.5.5 --build-arg PG_VERSION_TAG=$(PG_VER) $(TAG) .
@@ -24,8 +36,11 @@ push: image
 		docker push $(TAG_LATEST); \
 	fi
 
+multi: .multi_postgis_$(VERSION)_$(PG_VER)
+
 
 clean:
-	rm -f *~ .build_postgis_*
+	rm -f *~ .build_postgis_* .multi_*
+	docker buildx rm multibuild
 
-.PHONY: default image push clean
+.PHONY: default image push multi clean

--- a/postgis/Makefile
+++ b/postgis/Makefile
@@ -3,6 +3,7 @@ NAME=timescaledb-postgis
 # Set ORG to timescale in the caller
 ORG=timescaledev
 PG_VER=pg12
+POSTGIS_VERSION=2.5.5
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 VERSION=$(shell awk -F ':' '/^FROM/ { print $$2 }' Dockerfile | sed "s/\(.*\)-.*/\1/")
 # Beta releases should not be tagged as latest, so BETA is used to track.
@@ -19,13 +20,13 @@ default: image
 .multi_postgis_$(VERSION)_$(PG_VER): Dockerfile
 	docker buildx create --platform $(PLATFORM) --name multibuild --use
 	docker buildx inspect multibuild --bootstrap
-	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION=$(PG_VER_NUMBER) \
-		$(TAG) $(PUSH_MUTLI) .
+	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION_TAG=$(PG_VER_NUMBER) \
+		--build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) $(TAG) $(PUSH_MUTLI) .
 	touch .multi_$(VERSION)_$(PG_VER)
 	docker buildx rm multibuild
 
 .build_postgis_$(VERSION)_$(PG_VER): Dockerfile
-	docker build --build-arg POSTGIS_VERSION=2.5.5 --build-arg PG_VERSION_TAG=$(PG_VER) $(TAG) .
+	docker build --build-arg POSTGIS_VERSION=$(POSTGIS_VERSION) --build-arg PG_VERSION_TAG=$(PG_VER) $(TAG) .
 	touch .build_postgis_$(VERSION)_$(PG_VER)
 
 image: .build_postgis_$(VERSION)_$(PG_VER)
@@ -40,7 +41,7 @@ multi: .multi_postgis_$(VERSION)_$(PG_VER)
 
 
 clean:
-	rm -f *~ .build_postgis_* .multi_*
+	rm -f *~ .build_postgis_* .multi_postgis_*
 	docker buildx rm multibuild
 
 .PHONY: default image push multi clean


### PR DESCRIPTION
Added multi-arch `timescale-postgis` images build. 

Existed Issue #97: (timescale/timescaledb-postgis compatible with ARM) with considered problem


For test: [docker hub personal repo](https://hub.docker.com/r/k4black/timescaledb-postgis) with this images (build via [github-actions](https://github.com/k4black/timescaledb-docker/actions)).

---

Comments and discussion are welcome! 
