### PR TITLE
Remove hardcoded versions from Dockerfiles

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   ORG: timescale #timescaledev
+  TS_VERSION: 2.4.0
 
 jobs:
 
@@ -39,7 +40,7 @@ jobs:
       run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
     - name: Build and push multi-platform Docker image for TimescaleDB
-      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION
 
   # Build bitnami images of TimscaleDB.
   # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
@@ -60,6 +61,6 @@ jobs:
       run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
     - name: Build and push amd64 Docker image for TimescaleDB bitnami
-      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION
       working-directory: bitnami
 

--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -3,13 +3,14 @@ name: Docker Image Nightly Build CI
 on:
   push:
     branches: [ cron_build ]
-  
+
   schedule:
-    # run daily 0:00 
+    # run daily 0:00
     - cron: '0 0 * * *'
 
 env:
   ORG: timescaledev
+  TS_VERSION: master
 
 jobs:
 
@@ -25,17 +26,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      
+
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Linux available buildx platforms 
+    - name: Linux available buildx platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 
     - name: Login to DockerHub Registry
       run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
     - name: Build and push nightly Docker image for TimescaleDB
-      run: make nightly ORG=$ORG PG_VER=pg${{ matrix.pg }}
+      run: make nightly ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION
 

--- a/Makefile
+++ b/Makefile
@@ -4,57 +4,75 @@ NAME=timescaledb
 ORG=timescaledev
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
-VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
+TS_VERSION=master
+PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
 # Beta releases should not be tagged as latest, so BETA is used to track.
-BETA=$(findstring rc,$(VERSION))
+BETA=$(findstring rc,$(TS_VERSION))
 PLATFORM=linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
 NIGHTLY_PLATFORM=linux/amd64
 
 # PUSH_MULTI can be set to nothing for dry-run without pushing during multi-arch build
 PUSH_MULTI=--push
 TAG_NIGHTLY=-t timescaledev/timescaledb:nightly-$(PG_VER)
-TAG_VERSION=$(ORG)/$(NAME):$(VERSION)-$(PG_VER)
+TAG_VERSION=$(ORG)/$(NAME):$(TS_VERSION)-$(PG_VER)
 TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)
 TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 TAG_OSS=-t $(TAG_VERSION)-oss $(if $(BETA),,-t $(TAG_LATEST)-oss)
 
 default: image
 
-.multi_$(VERSION)_$(PG_VER)_oss: Dockerfile
+.multi_$(TS_VERSION)_$(PG_VER)_oss: Dockerfile
+	test -n "$(TS_VERSION)"  # TS_VERSION
+	test -n "$(PREV_TS_VERSION)"  # PREV_TS_VERSION
 	docker buildx create --platform $(PLATFORM) --name multibuild --use
 	docker buildx inspect multibuild --bootstrap
-	docker buildx build --platform $(PLATFORM) --build-arg PREV_EXTRA="-oss" --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) \
+	docker buildx build --platform $(PLATFORM) \
+		--build-arg TS_VERSION=$(TS_VERSION) \
+		--build-arg PREV_TS_VERSION=$(PREV_TS_VERSION) \
+		--build-arg PG_VERSION=$(PG_VER_NUMBER) \
+		--build-arg PREV_EXTRA="-oss" \
+		--build-arg OSS_ONLY=" -DAPACHE_ONLY=1" \
 		$(TAG_OSS) $(PUSH_MULTI) .
-	touch .multi_$(VERSION)_$(PG_VER)_oss
+	touch .multi_$(TS_VERSION)_$(PG_VER)_oss
 	docker buildx rm multibuild
 
-.multi_$(VERSION)_$(PG_VER): Dockerfile
+.multi_$(TS_VERSION)_$(PG_VER): Dockerfile
+	test -n "$(TS_VERSION)"  # TS_VERSION
+	test -n "$(PREV_TS_VERSION)"  # PREV_TS_VERSION
 	docker buildx create --platform $(PLATFORM) --name multibuild --use
 	docker buildx inspect multibuild --bootstrap
-	docker buildx build --platform $(PLATFORM) --build-arg PG_VERSION=$(PG_VER_NUMBER) \
+	docker buildx build --platform $(PLATFORM) \
+		--build-arg TS_VERSION=$(TS_VERSION) \
+		--build-arg PREV_TS_VERSION=$(PREV_TS_VERSION) \
+		--build-arg PG_VERSION=$(PG_VER_NUMBER) \
 		$(TAG) $(PUSH_MULTI) .
-	touch .multi_$(VERSION)_$(PG_VER)
+	touch .multi_$(TS_VERSION)_$(PG_VER)
 	docker buildx rm multibuild
 
 .nightly_$(PG_VER): Dockerfile
+	test -n "$(TS_VERSION)"  # TS_VERSION
+	test -n "$(PREV_TS_VERSION)"  # PREV_TS_VERSION
 	docker buildx create --platform $(NIGHTLY_PLATFORM) --name nightlybuild --use
 	docker buildx inspect nightlybuild --bootstrap
-	docker buildx build --platform $(NIGHTLY_PLATFORM) --build-arg PG_VERSION=$(PG_VER_NUMBER) \
+	docker buildx build --platform $(NIGHTLY_PLATFORM) \
+		--build-arg TS_VERSION=$(TS_VERSION) \
+		--build-arg PREV_TS_VERSION=$(PREV_TS_VERSION) \
+		--build-arg PG_VERSION=$(PG_VER_NUMBER) \
 		$(TAG_NIGHTLY) $(PUSH_MULTI) .
 	touch .nightly_$(PG_VER)
 	docker buildx rm nightlybuild
 
-.build_$(VERSION)_$(PG_VER)_oss: Dockerfile
+.build_$(TS_VERSION)_$(PG_VER)_oss: Dockerfile
 	docker build --build-arg PREV_EXTRA="-oss" --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) $(TAG_OSS) .
-	touch .build_$(VERSION)_$(PG_VER)_oss
+	touch .build_$(TS_VERSION)_$(PG_VER)_oss
 
-.build_$(VERSION)_$(PG_VER): Dockerfile
+.build_$(TS_VERSION)_$(PG_VER): Dockerfile
 	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) $(TAG) .
-	touch .build_$(VERSION)_$(PG_VER)
+	touch .build_$(TS_VERSION)_$(PG_VER)
 
-image: .build_$(VERSION)_$(PG_VER)
+image: .build_$(TS_VERSION)_$(PG_VER)
 
-oss: .build_$(VERSION)_$(PG_VER)_oss
+oss: .build_$(TS_VERSION)_$(PG_VER)_oss
 
 push: image
 	docker push $(TAG_VERSION)
@@ -68,9 +86,9 @@ push-oss: oss
 		docker push $(TAG_LATEST)-oss; \
 	fi
 
-multi: .multi_$(VERSION)_$(PG_VER)
+multi: .multi_$(TS_VERSION)_$(PG_VER)
 
-multi-oss: .multi_$(VERSION)_$(PG_VER)_oss
+multi-oss: .multi_$(TS_VERSION)_$(PG_VER)_oss
 
 nightly: .nightly_$(PG_VER)
 
@@ -78,7 +96,7 @@ all: multi multi-oss
 
 clean:
 	rm -f *~ .build_* .multi_* .nightly*
-	docker buildx rm nightlybuild
-	docker buildx rm multibuild
+	-docker buildx rm nightlybuild
+	-docker buildx rm multibuild
 
 .PHONY: default image push push-oss oss multi multi-oss clean all

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -1,5 +1,6 @@
 ARG PG_VERSION
-ARG PREV_TS_VERSION=2.3.1
+ARG TS_VERSION
+ARG PREV_TS_VERSION
 ############################
 # Build tools binaries in separate image
 ############################
@@ -28,6 +29,7 @@ RUN apk update && apk add --no-cache git \
 # Grab old versions from previous version
 ############################
 ARG PG_VERSION
+ARG PREV_TS_VERSION
 FROM timescale/timescaledb:${PREV_TS_VERSION}-pg${PG_VERSION}-bitnami AS oldversions
 # Remove update files, mock files, and all but the last 5 .so/.sql files
 USER 0
@@ -46,15 +48,13 @@ ARG PG_VERSION
 
 LABEL maintainer="Timescale https://www.timescale.com"
 
-# Update list above to include previous versions when changing this
-ENV TIMESCALEDB_VERSION 2.4.0
-
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/
 COPY --from=oldversions /opt/bitnami/postgresql/lib/timescaledb-*.so /opt/bitnami/postgresql/lib/
 COPY --from=oldversions /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /opt/bitnami/postgresql/share/extension/
 
 USER 0
+ARG TS_VERSION
 RUN set -ex \
     && mkdir -p /var/lib/apt/lists/partial \
     && apt-get update \
@@ -75,7 +75,7 @@ RUN set -ex \
     \
     # Build current version \
     && cd /build/timescaledb && rm -fr build \
-    && git checkout ${TIMESCALEDB_VERSION} \
+    && git checkout ${TS_VERSION} \
     && ./bootstrap -DREGRESS_CHECKS=OFF -DTAP_CHECKS=OFF -DGENERATE_DOWNGRADE_SCRIPT=ON -DWARNINGS_AS_ERRORS=OFF -DPROJECT_INSTALL_METHOD="docker-bitnami" \
     && cd build && make install \
     && cd ~ \

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -4,20 +4,25 @@ NAME=timescaledb
 ORG=timescaledev
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
-VERSION=$(shell awk '/^ENV TIMESCALEDB_VERSION/ {print $$3}' Dockerfile)
+
+TS_VERSION=master
+PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
+
 # Beta releases should not be tagged as latest, so BETA is used to track.
-BETA=$(findstring rc,$(VERSION))
-TAG_VERSION=$(ORG)/$(NAME):$(VERSION)-$(PG_VER)-bitnami
+BETA=$(findstring rc,$(TS_VERSION))
+TAG_VERSION=$(ORG)/$(NAME):$(TS_VERSION)-$(PG_VER)-bitnami
 TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)-bitnami
 TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 
 default: image
 
-.build_$(VERSION)_$(PG_VER): Dockerfile
-	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) $(TAG) ..
-	touch .build_$(VERSION)_$(PG_VER)-bitnami
+.build_$(TS_VERSION)_$(PG_VER): Dockerfile
+	test -n "$(TS_VERSION)"  # TS_VERSION
+	test -n "$(PREV_TS_VERSION)"  # PREV_TS_VERSION
+	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_TS_VERSION=$(PREV_TS_VERSION) $(TAG) ..
+	touch .build_$(TS_VERSION)_$(PG_VER)-bitnami
 
-image: .build_$(VERSION)_$(PG_VER)
+image: .build_$(TS_VERSION)_$(PG_VER)
 
 push: image
 	docker push $(TAG_VERSION)


### PR DESCRIPTION
This patch removes the hardcoded versions from the Dockerfile and
changes them into arguments. This removes the need to update the
version in multiple places when a new release is done and it also
removes the need to maintain the previous version as that can be
looked up. With this patch only 1 place in the CI file needs to be
updated on a new release.