### PR TITLE
Add workflow_dispatch to Docker release workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,13 +1,15 @@
-name: Docker Image CI
-
+name: Release Docker Image
 on:
   push:
     branches: [ release_docker, dev-build ]
-
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
 env:
   ORG: timescale #timescaledev
-  TS_VERSION: 2.4.2
-
+  TS_VERSION: ${{ github.event.inputs.version || '2.4.2' }}
 jobs:
 
   # Build multi-arch TimescaleDB images for both TSL and OSS code.
@@ -20,7 +22,6 @@ jobs:
       matrix:
         pg: [ 12, 13 ]
         oss: [ "", "-oss" ]
-
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Add `workflow_dispatch` event to release workflow so that the release
workflow can be triggered through the GitHub GUI, explicit
`workflow_dispatch` event sent to repository, or using the GitHub CLI.

Part of timescale/eng-database#74