### PR TITLE
Drop dependency on procps

### DIFF
--- a/docker-entrypoint-initdb.d/001_timescaledb_tune.sh
+++ b/docker-entrypoint-initdb.d/001_timescaledb_tune.sh
@@ -30,8 +30,8 @@ if [ -z "${TS_TUNE_MEMORY:-}" ]; then
             TS_TUNE_MEMORY=""
         fi
 
-        FREE_MB=$(free -m | grep 'Mem' | awk '{print $2}')
-        FREE_BYTES=$(( ${FREE_MB} * 1024 * 1024 ))
+        FREE_KB=$(grep MemTotal: /proc/meminfo | awk '{print $2}')
+        FREE_BYTES=$(( ${FREE_KB} * 1024 ))
         if [ ${TS_TUNE_MEMORY} -gt ${FREE_BYTES} ]; then
             # Something weird is going on if the cgroups memory limit exceeds the total available
             # amount of system memory reported by "free", which is the total amount of memory available on the host.


### PR DESCRIPTION
Stop using 'free' command as memory can be fetched from '/proc/meminfo'.
This drops dependency on the 'procps' package 'free' command belongs to.