### PR TITLE
add `pg_isready` healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,3 +77,5 @@ RUN set -ex \
     && apk del .fetch-deps .build-deps \
     && rm -rf /build \
     && sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /usr/local/share/postgresql/postgresql.conf.sample
+    
+HEALTCHECK CMD pg_isready -U postgres


### PR DESCRIPTION
The lack of a healthcheck is making this image painful to use as [a service in Gitlab CI](https://docs.gitlab.com/ee/ci/services/) because without a healthcheck it will start the container and then immediately move on to running the job script. Sometimes the database stands up quick enough to handle it, and sometimes not, giving us spurious "connection refused" errors.

It looks like the `pg_isready` command is available in the image as I have tested it locally and it works.

Closes #64