### PR TITLE
Fix Bitnami image detection

### DIFF
--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -3,7 +3,7 @@
 create_sql=`mktemp`
 
 # Checks to support bitnami image with same scripts so they stay in sync
-if [ ! -z "${BITNAMI_IMAGE_VERSION:-}" ]; then
+if [ ! -z "${BITNAMI_APP_NAME:-}" ]; then
 	if [ -z "${POSTGRES_USER:-}" ]; then
 		POSTGRES_USER=${POSTGRESQL_USERNAME}
 	fi


### PR DESCRIPTION
The environment variables have changed in the most recent versions of the Bitnami container images. So far, we have used the variable `BITNAMI_IMAGE_VERSION` to detect this kind of container image. However, this variable is no longer available. This patch changes the variable used for detection to `BITNAMI_APP_NAME`, which is currently available in all PostgreSQL container images:

```
for i in 12 13 14; do docker pull bitnami/postgresql:$i; docker run -it
  bitnami/postgresql:$i bash -c 'printenv | grep BITNAMI_'; done

docker.io/bitnami/postgresql:12
BITNAMI_ROOT_DIR=/opt/bitnami
BITNAMI_DEBUG=false
BITNAMI_VOLUME_DIR=/bitnami
BITNAMI_APP_NAME=postgresql

docker.io/bitnami/postgresql:13
BITNAMI_ROOT_DIR=/opt/bitnami
BITNAMI_DEBUG=false
BITNAMI_VOLUME_DIR=/bitnami
BITNAMI_APP_NAME=postgresql

docker.io/bitnami/postgresql:14
BITNAMI_ROOT_DIR=/opt/bitnami
BITNAMI_DEBUG=false
BITNAMI_VOLUME_DIR=/bitnami
BITNAMI_APP_NAME=postgresql
```

Fixes: #192