### PR TITLE
Fix the timescaledb-bitnami docker after the recent changes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,13 @@ on:
       version:
         description: 'Version to release'
         required: true
+      # This is a manual workaround until the latest tagging is fixed:
+      # https://github.com/timescale/timescaledb-docker/issues/205
+      no_tag_latest:
+        description: 'Do not tag the published images as latest'
+        type: boolean
+        required: false
+        default: false
 env:
   ORG: timescale #timescaledev
   TS_VERSION: ${{ github.event.inputs.version || '2.9.0' }}
@@ -23,25 +30,31 @@ jobs:
         pg: [12, 13, 14, 15]
         oss: [ "", "-oss" ]
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: all
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
 
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
 
-    - name: Login to DockerHub Registry
-      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
-    - name: Build and push multi-platform Docker image for TimescaleDB
-      run: make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION PREV_EXTRA="${{ matrix.oss }}"
+      - name: Build and push multi-platform Docker image for TimescaleDB
+        run: |
+          if [ "${{ github.event.inputs.no_tag_latest }}" == "true" ]
+          then
+              export BETA=1
+          fi
+          make multi${{ matrix.oss }} ORG=$ORG PG_VER=pg${{ matrix.pg }} \
+              TS_VERSION=$TS_VERSION PREV_EXTRA="${{ matrix.oss }}" BETA=$BETA
 
   # Build bitnami images of TimscaleDB.
   # The images are built only for amd64, since it is the only supported architecture in the base image bitname/postgresql.
@@ -56,12 +69,16 @@ jobs:
         pg: [12, 13, 14]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Login to DockerHub Registry
-      run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
 
-    - name: Build and push amd64 Docker image for TimescaleDB bitnami
-      run: make push ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION
-      working-directory: bitnami
-
+      - name: Build and push amd64 Docker image for TimescaleDB bitnami
+        run: |
+          if [ "${{ github.event.inputs.no_tag_latest }}" == "true" ]
+          then
+              export BETA=1
+          fi
+          make push ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION BETA=$BETA
+        working-directory: bitnami

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,68 @@
+name: Smoke Test Docker Image
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  ORG: timescaledev
+  TS_VERSION: main
+  PLATFORM: linux/amd64
+
+jobs:
+  smoketest:
+    name: PG${{ matrix.pg }}-${{ matrix.type }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [12,13,14]
+        type: ['normal', 'bitnami']
+    steps:
+      - name: Check out the source
+        uses: actions/checkout@v3
+
+      - name: Build Docker Image for TimescaleDB
+        run: |
+          if [ ${{ matrix.type }} == bitnami ]
+          then
+            cd bitnami
+          fi
+          make image PG_VER=pg${{ matrix.pg }} TAG_VERSION=smoketest-image BETA=1
+
+      - name: Install psql
+        run: sudo apt install postgresql-client
+
+      - name: Run the smoke test
+        run: |
+          set -eu
+          export PGHOST=localhost
+          export PGUSER=postgres
+          export PGPASSWORD=test1234
+          docker container stop smoketest-container || true
+          docker container rm smoketest-container || true
+          docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=${PGPASSWORD} --name smoketest-container smoketest-image
+          for _ in {1..120}
+          do
+            if [ -z "$(docker container ls -q --filter name=smoketest-container)" ]
+            then
+              echo "Smoketest container is not running"
+              exit 1
+            fi
+            if psql -c "select 1"
+            then
+              break
+            fi
+            sleep 1
+          done
+          if ! psql -c "select 1"
+          then
+            echo "Cannot connect to PostgreSQL"
+            exit 1
+          fi
+
+      - name: Show the logs
+        if: always()
+        run: |
+          docker logs smoketest-container

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ default: image
 	touch .build_$(TS_VERSION)_$(PG_VER)_oss
 
 .build_$(TS_VERSION)_$(PG_VER): Dockerfile
-	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) $(TAG) .
+	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) $(TAG) .
 	touch .build_$(TS_VERSION)_$(PG_VER)
 
 image: .build_$(TS_VERSION)_$(PG_VER)

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -19,12 +19,20 @@ RUN apk update && apk add --no-cache git gcc \
 ARG PG_VERSION
 ARG PREV_IMAGE
 FROM ${PREV_IMAGE} AS oldversions
-# Remove update files, mock files, and all but the last 5 .so/.sql files
+# Remove update files, mock files, and all but the last 5 .so/.sql files.
+# There are three types of SQL files, initialization, upgrade, and downgrade,
+# which we have to count separately, but it's hard to match with globs, and
+# there are also many upgrade/downgrade files per version, so just keep more of
+# them.
 USER 0
-RUN rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
-    && if [ -f $(pg_config --pkglibdir)/timescaledb-tsl-1*.so ]; then rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-tsl-1*.so | head -n -5); fi \
-    && if [ -f $(pg_config --pkglibdir)/timescaledb-1*.so ]; then rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-*.so | head -n -5); fi \
-    && if [ -f $(pg_config --sharedir)/extension/timescaledb--1*.sql ]; then rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb--1*.sql | head -n -5); fi
+RUN set +o pipefail \
+    && rm -vf $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
+    && rm -vf $(ls -1tr $(pg_config --pkglibdir)/timescaledb-tsl-*.so | head -n -5) \
+    && rm -vf $(ls -1tr $(pg_config --pkglibdir)/timescaledb-[0-9]*.so | head -n -5) \
+    && rm -vf $(ls -1tr $(pg_config --sharedir)/extension/timescaledb--*.sql | head -n -20) \
+    && { ls $(pg_config --sharedir)/extension/timescaledb--*.sql \
+      ; ls $(pg_config --pkglibdir)/timescaledb-*.so \
+      ; : ; }
 
 ############################
 # Now build image and copy in tools
@@ -39,6 +47,7 @@ COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/
 COPY --from=oldversions /opt/bitnami/postgresql/lib/timescaledb-*.so /opt/bitnami/postgresql/lib/
 COPY --from=oldversions /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /opt/bitnami/postgresql/share/extension/
+COPY bitnami/timescaledb-bitnami-entrypoint.sh /opt/bitnami/scripts/postgresql/
 
 USER 0
 ARG TS_VERSION
@@ -79,10 +88,13 @@ RUN set -ex \
             cmake \
     && apt-get clean -y \
     && rm -rf \
-      "${HOME}/.cache" \
+        /build \
+        "${HOME}/.cache" \
         /var/lib/apt/lists/* \
         /tmp/*               \
         /var/tmp/*
-RUN sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /opt/bitnami/postgresql/share/postgresql.conf.sample /opt/bitnami/postgresql/conf/postgresql.conf
 
 USER 1001
+
+ENTRYPOINT [ "/opt/bitnami/scripts/postgresql/timescaledb-bitnami-entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/postgresql/run.sh" ]

--- a/bitnami/timescaledb-bitnami-entrypoint.sh
+++ b/bitnami/timescaledb-bitnami-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# We have to use the bitnami configuration variable to add timescaledb to
+# shared preload list, or else it gets overwritten.
+if [ -z "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]
+then
+    POSTGRESQL_SHARED_PRELOAD_LIBRARIES=timescaledb
+else
+    POSTGRESQL_SHARED_PRELOAD_LIBRARIES="$POSTGRESQL_SHARED_PRELOAD_LIBRARIES,timescaledb"
+fi
+export POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+
+# Fall through to the original entrypoint.
+/opt/bitnami/scripts/postgresql/entrypoint.sh "$@"

--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -38,6 +38,7 @@ fi
 
 echo "timescaledb.telemetry_level=${TS_TELEMETRY}" >> ${POSTGRESQL_CONF_DIR}/postgresql.conf
 
+export PGPASSWORD="$POSTGRESQL_PASSWORD"
 
 # create extension timescaledb in initial databases
 psql -U "${POSTGRES_USER}" postgres -f ${create_sql}


### PR DESCRIPTION
They changed two things:
- disabled trust authentication for localhost
- started replacing the original config, overwriting shared_preload_libraries configured by us from their config environment variable POSTGRESQL_SHARED_PRELOAD_LIBRARIES.

This commit accounts for these things, and also makes some cosmetic changes.

Fixes #203