### PR TITLE
Add PG 15 bitnami builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,7 @@ on:
         default: false
 env:
   ORG: timescale #timescaledev
-  TS_VERSION: ${{ github.event.inputs.version || '2.9.0' }}
+  TS_VERSION: ${{ github.event.inputs.version || '2.10.0' }}
 jobs:
 
   # Build multi-arch TimescaleDB images for both TSL and OSS code.
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [12, 13, 14]
+        pg: [12, 13, 14, 15]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [12,13,14]
+        pg: [12,13,14,15]
         type: ['normal', 'bitnami']
     steps:
       - name: Check out the source


### PR DESCRIPTION
* Smoketest for PG 15 bitnami fails because there is no published `PREV_IMAGE` for that version that can be used in the smoketest
* Bumped up default version from 2.9 to 2.10 to fixed build problems with PG 15