### PR TITLE
Fix first bitnami build for new PG version

### DIFF
--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -25,6 +25,15 @@ FROM ${PREV_IMAGE} AS oldversions
 # there are also many upgrade/downgrade files per version, so just keep more of
 # them.
 USER 0
+
+# Docker COPY needs at least one file to copy. If no source is specified, the
+# command fails. Create two '.emptyfile' files here to prevent the
+# 'COPY --from=oldversions' command below from failing. The files are removed
+# after the copy operation is performed.
+#
+# When the first image for a PG version is created, PREV_IMAGE is set to the
+# bitnami upstream image. Therefore, no TimescaleDB files exist and the
+# copy commands would fail.
 RUN set +o pipefail \
     && rm -vf $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
     && rm -vf $(ls -1tr $(pg_config --pkglibdir)/timescaledb-tsl-*.so | head -n -5) \
@@ -32,7 +41,9 @@ RUN set +o pipefail \
     && rm -vf $(ls -1tr $(pg_config --sharedir)/extension/timescaledb--*.sql | head -n -20) \
     && { ls $(pg_config --sharedir)/extension/timescaledb--*.sql \
       ; ls $(pg_config --pkglibdir)/timescaledb-*.so \
-      ; : ; }
+      ; : ; } \
+    && touch $(pg_config --sharedir)/extension/.emptyfile \
+    && touch $(pg_config --pkglibdir)/.emptyfile
 
 ############################
 # Now build image and copy in tools
@@ -45,13 +56,15 @@ LABEL maintainer="Timescale https://www.timescale.com"
 
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/
-COPY --from=oldversions /opt/bitnami/postgresql/lib/timescaledb-*.so /opt/bitnami/postgresql/lib/
-COPY --from=oldversions /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /opt/bitnami/postgresql/share/extension/
+COPY --from=oldversions /opt/bitnami/postgresql/lib/.emptyfile /opt/bitnami/postgresql/lib/timescaledb-*.so /opt/bitnami/postgresql/lib/
+COPY --from=oldversions /opt/bitnami/postgresql/share/extension/.emptyfile /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /opt/bitnami/postgresql/share/extension/
 COPY bitnami/timescaledb-bitnami-entrypoint.sh /opt/bitnami/scripts/postgresql/
 
 USER 0
 ARG TS_VERSION
 RUN set -ex \
+    && rm -v /opt/bitnami/postgresql/lib/.emptyfile \
+    && rm -v /opt/bitnami/postgresql/share/extension/.emptyfile \
     && mkdir -p /var/lib/apt/lists/partial \
     && apt-get update \
     && apt-get -y install \


### PR DESCRIPTION
Perform a workaround for failing docker `COPY` commands when no input files [are specified](https://github.com/timescale/timescaledb-docker/actions/runs/4261012869/jobs/7414832910#step:4:150). 

When the first image for a PG version is created, `PREV_IMAGE` is set to the Bitnami upstream image. Therefore, no TimescaleDB files exist and the [copy commands](https://github.com/timescale/timescaledb-docker/blob/d0e40052564fba696a47c4fe5ff190ead72baa6a/bitnami/Dockerfile#L48) do fail. After applying this patch, the Bitnami image for PG 15 can be created. The image building and the image are tested locally. 

```
Password for user postgres: 
psql (15.2)
Type "help" for help.

postgres=# \dx
                                      List of installed extensions
    Name     | Version |   Schema   |                            Description                            
-------------+---------+------------+-------------------------------------------------------------------
 plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
 timescaledb | 2.10.0  | public     | Enables scalable inserts and complex queries for time-series data
(2 rows)
```