### PR TITLE
Add bitnami postgresql-repmgr

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -61,12 +61,13 @@ jobs:
   # The images are only built for TSL code.
   timescaledb-bitnami:
 
-    name: PG${{ matrix.pg }}-bitnami
+    name: PG${{ matrix.pg }}-${{ matrix.base-image }}-bitnami
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         pg: [13, 14, 15, 16]
+        base-image: [postgresql, postgresql-repmgr]
 
     steps:
       - uses: actions/checkout@v3
@@ -80,5 +81,5 @@ jobs:
           then
               export BETA=1
           fi
-          make push ORG=$ORG PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION BETA=$BETA
+          make push ORG=$ORG PG_BASE_IMAGE=${{ matrix.base-image }} PG_VER=pg${{ matrix.pg }} TS_VERSION=$TS_VERSION BETA=$BETA
         working-directory: bitnami

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -18,18 +18,25 @@ jobs:
       fail-fast: false
       matrix:
         pg: [13, 14, 15, 16]
-        type: ['normal', 'bitnami']
+        type: ['normal', 'repmgr-bitnami', 'bitnami']
     steps:
       - name: Check out the source
         uses: actions/checkout@v3
 
       - name: Build Docker Image for TimescaleDB
         run: |
+          
           if [ ${{ matrix.type }} == bitnami ]
           then
             cd bitnami
+            make image PG_BASE_IMAGE=postgresql PG_VER=pg${{ matrix.pg }} TAG_VERSION=smoketest-image BETA=1
+          elif [ ${{ matrix.type }} == repmgr-bitnami ] 
+          then
+            cd bitnami
+            make image PG_BASE_IMAGE=postgresql-repmgr PG_VER=pg${{ matrix.pg }} TAG_VERSION=smoketest-image BETA=1
+          else
+            make image PG_VER=pg${{ matrix.pg }} TAG_VERSION=smoketest-image BETA=1
           fi
-          make image PG_VER=pg${{ matrix.pg }} TAG_VERSION=smoketest-image BETA=1
 
       - name: Install psql
         run: sudo apt install postgresql-client
@@ -42,7 +49,16 @@ jobs:
           export PGPASSWORD=test1234
           docker container stop smoketest-container || true
           docker container rm smoketest-container || true
-          docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=${PGPASSWORD} --name smoketest-container smoketest-image
+          docker run -d -p 5432:5432 \
+            -e POSTGRES_PASSWORD=${PGPASSWORD} \
+            -e REPMGR_PASSWORD=${PGPASSWORD} \
+            -e REPMGR_PRIMARY_HOST=localhost \
+            -e REPMGR_PRIMARY_PORT=5432 \
+            -e REPMGR_PARTNER_NODES=pg-0,pg-1 \
+            -e REPMGR_NODE_NAME=pg-0 \
+            -e REPMGR_NODE_NETWORK_NAME=localhost \
+            -e REPMGR_PORT_NUMBER=5432 \
+            --name smoketest-container smoketest-image
           for _ in {1..120}
           do
             if [ -z "$(docker container ls -q --filter name=smoketest-container)" ]

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -1,3 +1,4 @@
+ARG PG_BASE_IMAGE
 ARG PG_VERSION
 ARG PREV_IMAGE
 ARG TS_VERSION
@@ -48,8 +49,10 @@ RUN set +o pipefail \
 ############################
 # Now build image and copy in tools
 ############################
+ARG PG_BASE_IMAGE
 ARG PG_VERSION
-FROM bitnami/postgresql:${PG_VERSION}
+FROM bitnami/${PG_BASE_IMAGE}:${PG_VERSION} AS timescale
+ARG PG_BASE_IMAGE
 ARG PG_VERSION
 
 LABEL maintainer="Timescale https://www.timescale.com"
@@ -58,7 +61,7 @@ COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/
 COPY --from=oldversions /opt/bitnami/postgresql/lib/.emptyfile /opt/bitnami/postgresql/lib/timescaledb-*.so /opt/bitnami/postgresql/lib/
 COPY --from=oldversions /opt/bitnami/postgresql/share/extension/.emptyfile /opt/bitnami/postgresql/share/extension/timescaledb--*.sql /opt/bitnami/postgresql/share/extension/
-COPY bitnami/timescaledb-bitnami-entrypoint.sh /opt/bitnami/scripts/postgresql/
+COPY bitnami/timescaledb-bitnami-entrypoint.sh /opt/bitnami/scripts/timescale/
 
 USER 0
 ARG TS_VERSION
@@ -109,5 +112,15 @@ RUN set -ex \
 
 USER 1001
 
-ENTRYPOINT [ "/opt/bitnami/scripts/postgresql/timescaledb-bitnami-entrypoint.sh" ]
+FROM timescale AS timescale-postgresql
+ENTRYPOINT [ "/opt/bitnami/scripts/timescale/timescaledb-bitnami-entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/postgresql/run.sh" ]
+
+FROM timescale AS timescale-postgresql-repmgr
+ENTRYPOINT [ "/opt/bitnami/scripts/timescale/timescaledb-bitnami-entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/postgresql-repmgr/run.sh" ]
+
+FROM timescale-${PG_BASE_IMAGE}
+ARG PG_BASE_IMAGE
+ENV PG_BASE_IMAGE=${PG_BASE_IMAGE}
+ENV PG_ORIGINAL_ENTRYPOINT_PATH="/opt/bitnami/scripts/${PG_BASE_IMAGE}"

--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -2,29 +2,31 @@ NAME=timescaledb
 # Default is to timescaledev to avoid unexpected push to the main repo
 # Set ORG to timescale in the caller
 ORG=timescaledev
+PG_BASE_IMAGE=postgresql
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
-
+PG_IMAGE_SUFFIX=$(shell if "$(PG_BASE_IMAGE)" == "postgresql-repmgr"; then echo "bitnami"; else echo "repmgr-bitnami"; fi )
+PREV_IMAGE=$(shell if docker pull $(PREV_TS_IMAGE) >/dev/null; then echo "$(PREV_TS_IMAGE)"; else echo "bitnami/$(PG_BASE_IMAGE):$(PG_VER_NUMBER)"; fi )
 TS_VERSION=main
 PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
-PREV_TS_IMAGE="timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)-bitnami"
-PREV_IMAGE=$(shell if docker pull $(PREV_TS_IMAGE) >/dev/null; then echo "$(PREV_TS_IMAGE)"; else echo "bitnami/postgresql:$(PG_VER_NUMBER)"; fi )
+PREV_TS_IMAGE="timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)-$(PG_IMAGE_SUFFIX)"
+PREV_IMAGE=$(shell if docker pull $(PREV_TS_IMAGE) >/dev/null; then echo "$(PREV_TS_IMAGE)"; else echo "bitnami/$(PG_BASE_IMAGE):$(PG_VER_NUMBER)"; fi )
 
 # Beta releases should not be tagged as latest, so BETA is used to track.
 BETA=$(findstring rc,$(TS_VERSION))
-TAG_VERSION=$(ORG)/$(NAME):$(TS_VERSION)-$(PG_VER)-bitnami
-TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)-bitnami
+TAG_VERSION=$(ORG)/$(NAME):$(TS_VERSION)-$(PG_VER)-$(PG_IMAGE_SUFFIX)
+TAG_LATEST=$(ORG)/$(NAME):latest-$(PG_VER)-$(PG_IMAGE_SUFFIX)
 TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 
 default: image
 
-.build_$(TS_VERSION)_$(PG_VER): Dockerfile
+.build_$(PG_BASE_IMAGE)_$(TS_VERSION)_$(PG_VER): Dockerfile
 	test -n "$(TS_VERSION)"  # TS_VERSION
 	test -n "$(PREV_TS_VERSION)"  # PREV_TS_VERSION
-	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) $(TAG) ..
-	touch .build_$(TS_VERSION)_$(PG_VER)-bitnami
+	docker build -f ./Dockerfile --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg PG_BASE_IMAGE=$(PG_BASE_IMAGE) $(TAG) ..
+	touch .build_$(PG_BASE_IMAGE)_$(TS_VERSION)_$(PG_VER)-bitnami
 
-image: .build_$(TS_VERSION)_$(PG_VER)
+image: .build_$(PG_BASE_IMAGE)_$(TS_VERSION)_$(PG_VER)
 
 push: image
 	docker push $(TAG_VERSION)

--- a/bitnami/timescaledb-bitnami-entrypoint.sh
+++ b/bitnami/timescaledb-bitnami-entrypoint.sh
@@ -10,6 +10,13 @@ else
 fi
 export POSTGRESQL_SHARED_PRELOAD_LIBRARIES
 
+# Timescale tuning breaks standby nodes on repmgr clusters, so we disable it
+# by default
+if [ "$PG_BASE_IMAGE" == "postgresql-repmgr" ]
+then
+    export NO_TS_TUNE=true
+fi
+
 # Fall through to the original entrypoint. Note that we use exec here because
 # this wrapper script shouldn't change PID 1 of the container.
-exec /opt/bitnami/scripts/postgresql/entrypoint.sh "$@"
+exec "${PG_ORIGINAL_ENTRYPOINT_PATH}/entrypoint.sh" "$@"

--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -5,7 +5,11 @@ create_sql=`mktemp`
 # Checks to support bitnami image with same scripts so they stay in sync
 if [ ! -z "${BITNAMI_APP_NAME:-}" ]; then
 	if [ -z "${POSTGRES_USER:-}" ]; then
-		POSTGRES_USER=${POSTGRESQL_USERNAME}
+		POSTGRES_USER=postgres
+	fi
+
+	if [ -z "${POSTGRESQL_PASSWORD:-}" ]; then
+		POSTGRESQL_PASSWORD=${POSTGRESQL_POSTGRES_PASSWORD}
 	fi
 
 	if [ -z "${POSTGRES_DB:-}" ]; then


### PR DESCRIPTION
Adding a new docker images based on bitnami/postgresql-repmgr to enable the usage of Timescale on the [postgresql-ha helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha), which needs the bitnami/postgresql-repmgr instead of the already supported bitnami/postgresql.

This implementation aims to reduce duplication and so I've added a new build parameter that changes the base image used to build the Docker image.
If you prefer separate Dockerfiles/Makefiles let me know, I'll redo a new PR 🙂