### PR TITLE
Avoid confusion with POSTGRES(QL)_PASSWORD

### DIFF
--- a/docker-entrypoint-initdb.d/000_install_timescaledb.sh
+++ b/docker-entrypoint-initdb.d/000_install_timescaledb.sh
@@ -38,6 +38,9 @@ fi
 
 echo "timescaledb.telemetry_level=${TS_TELEMETRY}" >> ${POSTGRESQL_CONF_DIR}/postgresql.conf
 
+if [ -z "${POSTGRESQL_PASSWORD:-}" ]; then
+	POSTGRESQL_PASSWORD=${POSTGRES_PASSWORD}
+fi
 export PGPASSWORD="$POSTGRESQL_PASSWORD"
 
 # create extension timescaledb in initial databases


### PR DESCRIPTION
In the Postgres Docker documentation  `POSTGRES_PASSWORD`  is used, but here it needs to be `POSTGRESQL_PASSWORD`...