### PR TITLE
Unify old TSDB version cleanup code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,9 @@ RUN apk update && apk add --no-cache git gcc musl-dev \
 ARG PG_VERSION
 ARG PREV_IMAGE
 FROM ${PREV_IMAGE} AS oldversions
-# Remove update files, mock files, and all but the last 5 .so/.sql files
-RUN rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
-    && if [ -f $(pg_config --pkglibdir)/timescaledb-tsl-1*.so ]; then rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-tsl-1*.so | head -n -5); fi \
-    && if [ -f $(pg_config --pkglibdir)/timescaledb-1*.so ]; then rm -f $(ls -1 $(pg_config --pkglibdir)/timescaledb-*.so | head -n -5); fi \
-    && if [ -f $(pg_config --sharedir)/extension/timescaledb--1*.sql ]; then rm -f $(ls -1 $(pg_config --sharedir)/extension/timescaledb--1*.sql | head -n -5); fi
+
+# Remove mock files
+RUN rm -f $(pg_config --sharedir)/extension/timescaledb*mock*.sql
 
 ############################
 # Now build image and copy in tools

--- a/bitnami/Dockerfile
+++ b/bitnami/Dockerfile
@@ -20,13 +20,10 @@ RUN apk update && apk add --no-cache git gcc \
 ARG PG_VERSION
 ARG PREV_IMAGE
 FROM ${PREV_IMAGE} AS oldversions
-# Remove update files, mock files, and all but the last 5 .so/.sql files.
-# There are three types of SQL files, initialization, upgrade, and downgrade,
-# which we have to count separately, but it's hard to match with globs, and
-# there are also many upgrade/downgrade files per version, so just keep more of
-# them.
 USER 0
 
+# Remove mock files
+#
 # Docker COPY needs at least one file to copy. If no source is specified, the
 # command fails. Create two '.emptyfile' files here to prevent the
 # 'COPY --from=oldversions' command below from failing. The files are removed
@@ -37,12 +34,6 @@ USER 0
 # copy commands would fail.
 RUN set +o pipefail \
     && rm -vf $(pg_config --sharedir)/extension/timescaledb*mock*.sql \
-    && rm -vf $(ls -1tr $(pg_config --pkglibdir)/timescaledb-tsl-*.so | head -n -5) \
-    && rm -vf $(ls -1tr $(pg_config --pkglibdir)/timescaledb-[0-9]*.so | head -n -5) \
-    && rm -vf $(ls -1tr $(pg_config --sharedir)/extension/timescaledb--*.sql | head -n -20) \
-    && { ls $(pg_config --sharedir)/extension/timescaledb--*.sql \
-      ; ls $(pg_config --pkglibdir)/timescaledb-*.so \
-      ; : ; } \
     && touch $(pg_config --sharedir)/extension/.emptyfile \
     && touch $(pg_config --pkglibdir)/.emptyfile
 


### PR DESCRIPTION
Removed dead code to delete version 1.x TSDB versions and keep old versions in the Bitnami image.

Fixes: #232