### PR TITLE
Fix bitnami base image logic bug

### DIFF
--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -2,10 +2,10 @@ NAME=timescaledb
 # Default is to timescaledev to avoid unexpected push to the main repo
 # Set ORG to timescale in the caller
 ORG=timescaledev
-PG_BASE_IMAGE=postgresql
+PG_BASE_IMAGE=${PG_BASE_IMAGE:-postgresql}
 PG_VER=pg12
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
-PG_IMAGE_SUFFIX=$(shell if "$(PG_BASE_IMAGE)" == "postgresql-repmgr"; then echo "bitnami"; else echo "repmgr-bitnami"; fi )
+PG_IMAGE_SUFFIX=$(shell if "$(PG_BASE_IMAGE)" == "postgresql"; then echo "bitnami"; else echo "repmgr-bitnami"; fi )
 PREV_IMAGE=$(shell if docker pull $(PREV_TS_IMAGE) >/dev/null; then echo "$(PREV_TS_IMAGE)"; else echo "bitnami/$(PG_BASE_IMAGE):$(PG_VER_NUMBER)"; fi )
 TS_VERSION=main
 PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')


### PR DESCRIPTION
The base image name was always set to postgresql in the Makefile instead of respecting the passed in value from the workflow.