### PR TITLE
Add plpython3, pgvector, and pgai extensions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 *~
 .build_*
+.github
+.idea

--- a/.github/workflows/bitnami.yml
+++ b/.github/workflows/bitnami.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [13, 14, 15, 16]
+        pg: [14, 15, 16]
         base-image: [postgresql, postgresql-repmgr]
 
     steps:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [13, 14, 15, 16]
+        pg: [14, 15, 16]
         oss: [ "", "-oss" ]
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 /.build_*
 */.build_*
+.idea


### PR DESCRIPTION
This adds several new extensions to the image including:

1. plpython3
2. pgvector
3. pgai

To add plpython3 on pg16, we needed to bump from Alpine 3.18 to Alpine 3.20. Alpine 3.20 does not have plpython3 packages for pg13. Timescaledb no longer supports pg13 anyway, so we dropped support for it.