### PR TITLE
Include python3-dev for building dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,9 @@ RUN set -ex; \
         apk update; \
         apk add --no-cache --virtual .pgai-deps \
             git \
+            build-base \
             cargo \
+            python3-dev \
             py3-pip; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cp /build/pgai/ai--*.sql /usr/local/share/postgresql/extension/; \


### PR DESCRIPTION
On some platforms, the regex python package has to build from source. To do that, the python3-dev package is needed.