### PR TITLE
Exclude pgai from 32bit ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,9 @@ LABEL maintainer="Timescale https://www.timescale.com"
 
 # install pgai only on pg16+
 ARG PGAI_VERSION
+ARG PG_MAJOR_VERSION
 RUN set -ex; \
-    if [ "$PG_VERSION" -gt 15 ]; then \
+    if [ "$PG_MAJOR_VERSION" -gt 15 ]; then \
         apk update; \
         apk add --no-cache --virtual .pgai-deps \
             git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,24 +32,6 @@ ARG OSS_ONLY
 
 LABEL maintainer="Timescale https://www.timescale.com"
 
-# install pgai only on pg16+
-ARG PGAI_VERSION
-ARG PG_MAJOR_VERSION
-RUN set -ex; \
-    if [ "$PG_MAJOR_VERSION" -gt 15 ]; then \
-        apk update; \
-        apk add --no-cache --virtual .pgai-deps \
-            git \
-            cargo \
-            python3-dev \
-            py3-pip; \
-        git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
-        cp /build/pgai/ai--*.sql /usr/local/share/postgresql/extension/; \
-        cp /build/pgai/ai.control /usr/local/share/postgresql/extension/; \
-        pip install --verbose --break-system-packages -r /build/pgai/requirements.txt; \
-        apk del .pgai-deps; \
-    fi
-
 ARG PG_VERSION
 RUN set -ex; \
     apk update; \
@@ -72,6 +54,25 @@ RUN set -ex; \
     make install; \
     apk del .vector-deps
 
+# install pgai only on pg16+ and not on arm
+ARG PGAI_VERSION
+ARG PG_MAJOR_VERSION
+ARG TARGETARCH
+RUN set -ex; \
+    if [ "$PG_MAJOR_VERSION" -gt 15 && "$TARGETARCH" != "arm" ]; then \
+        apk update; \
+        apk add --no-cache --virtual .pgai-deps \
+            git \
+            build-base \
+            cargo \
+            python3-dev \
+            py3-pip; \
+        git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
+        cp /build/pgai/ai--*.sql /usr/local/share/postgresql/extension/; \
+        cp /build/pgai/ai.control /usr/local/share/postgresql/extension/; \
+        pip install --verbose --break-system-packages -r /build/pgai/requirements.txt; \
+        apk del .pgai-deps; \
+    fi
 
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY --from=tools /go/bin/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ NAME=timescaledb
 ORG=timescaledev
 PG_VER=pg16
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
+PG_MAJOR_VERSION=$(shell echo $(PG_VER_NUMBER) | cut -d. -f1)
 TS_VERSION=main
 PREV_TS_VERSION=$(shell wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${TS_VERSION}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
 PREV_TS_IMAGE="timescale/timescaledb:$(PREV_TS_VERSION)-pg$(PG_VER_NUMBER)$(PREV_EXTRA)"
@@ -32,6 +33,7 @@ default: image
 	docker buildx build --platform $(PLATFORM) \
 		--build-arg TS_VERSION=$(TS_VERSION) \
 		--build-arg PG_VERSION=$(PG_VER_NUMBER) \
+		--build-arg PG_MAJOR_VERSION=$(PG_MAJOR_VERSION) \
 		--build-arg PREV_IMAGE=$(PREV_IMAGE) \
 		--build-arg OSS_ONLY=" -DAPACHE_ONLY=1" \
 		--build-arg PGVECTOR_VERSION=$(PGVECTOR_VERSION) \
@@ -50,6 +52,7 @@ default: image
 		--build-arg TS_VERSION=$(TS_VERSION) \
 		--build-arg PREV_IMAGE=$(PREV_IMAGE) \
 		--build-arg PG_VERSION=$(PG_VER_NUMBER) \
+		--build-arg PG_MAJOR_VERSION=$(PG_MAJOR_VERSION) \
 		--build-arg PGVECTOR_VERSION=$(PGVECTOR_VERSION) \
 		--build-arg PGAI_VERSION=$(PGAI_VERSION) \
 		$(TAG) $(PUSH_MULTI) .
@@ -57,11 +60,11 @@ default: image
 	docker buildx rm multibuild
 
 .build_$(TS_VERSION)_$(PG_VER)_oss: Dockerfile
-	docker build --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg PGVECTOR_VERSION=$(PGVECTOR_VERSION) --build-arg PGAI_VERSION=$(PGAI_VERSION) $(TAG_OSS) .
+	docker build --build-arg OSS_ONLY=" -DAPACHE_ONLY=1" --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg PG_MAJOR_VERSION=$(PG_MAJOR_VERSION) --build-arg PGVECTOR_VERSION=$(PGVECTOR_VERSION) --build-arg PGAI_VERSION=$(PGAI_VERSION) $(TAG_OSS) .
 	touch .build_$(TS_VERSION)_$(PG_VER)_oss
 
 .build_$(TS_VERSION)_$(PG_VER): Dockerfile
-	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg PGVECTOR_VERSION=$(PGVECTOR_VERSION) --build-arg PGAI_VERSION=$(PGAI_VERSION) $(TAG) .
+	docker build --build-arg PG_VERSION=$(PG_VER_NUMBER) --build-arg PG_MAJOR_VERSION=$(PG_MAJOR_VERSION) --build-arg TS_VERSION=$(TS_VERSION) --build-arg PREV_IMAGE=$(PREV_IMAGE) --build-arg PGVECTOR_VERSION=$(PGVECTOR_VERSION) --build-arg PGAI_VERSION=$(PGAI_VERSION) $(TAG) .
 	touch .build_$(TS_VERSION)_$(PG_VER)
 
 image: .build_$(TS_VERSION)_$(PG_VER)


### PR DESCRIPTION
Several required Python packages have to be built from source on 32bit ARM. Building from source causes the github action to stall and fail.