### PR TITLE
Removed bitnami images for older PG versions

### DIFF
--- a/.github/workflows/bitnami.yml
+++ b/.github/workflows/bitnami.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [14, 15, 16, 17]
-        base-image: [postgresql, postgresql-repmgr]
+        pg: [17]
+        base-image: [postgresql]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Bitnami dropped support for LTS PG versions. So we will no longer support older PG versions for bitnami images.