### PR TITLE
feat: upgrade pgai extension to v0.7.0

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   smoketest:
     name: PG${{ matrix.pg }}-${{ matrix.type }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ORG: timescaledev
   TS_VERSION: main

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   smoketest:
     name: PG${{ matrix.pg }}-${{ matrix.type }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,10 +70,14 @@ RUN set -ex; \
             git \
             build-base \
             cargo \
+            cmake \
             python3-dev \
+            apache-arrow-dev \
             py3-pip; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
+        # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
+        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
             echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,10 @@ RUN set -ex; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
         # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
-        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/requirements.txt; \
+        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/old_requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
-            echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \
+            echo pandas==2.1.4 >> ./projects/extension/old_requirements.txt; \
             # note: no prebuilt binaries for pillow on i386 \
             apk add --no-cache --virtual .pgai-deps-386 \
                 jpeg-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,15 +72,15 @@ RUN set -ex; \
             cargo \
             cmake \
             python3-dev \
-            apache-arrow-dev=18.1.0 --force \
+            apache-arrow-dev \
             py3-pip; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
         # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
-        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/old_requirements.txt; \
+        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
-            echo pandas==2.1.4 >> ./projects/extension/old_requirements.txt; \
+            echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \
             # note: no prebuilt binaries for pillow on i386 \
             apk add --no-cache --virtual .pgai-deps-386 \
                 jpeg-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,10 @@ RUN set -ex; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
         # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
-        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/old_requirements.txt; \
+        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
-            echo pandas==2.1.4 >> ./projects/extension/old_requirements.txt; \
+            echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \
             # note: no prebuilt binaries for pillow on i386 \
             apk add --no-cache --virtual .pgai-deps-386 \
                 jpeg-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,15 +72,15 @@ RUN set -ex; \
             cargo \
             cmake \
             python3-dev \
-            apache-arrow-dev \
+            apache-arrow-dev=18.1.0 \
             py3-pip; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
         # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
-        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/requirements.txt; \
+        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/old_requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
-            echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \
+            echo pandas==2.1.4 >> ./projects/extension/old_requirements.txt; \
             # note: no prebuilt binaries for pillow on i386 \
             apk add --no-cache --virtual .pgai-deps-386 \
                 jpeg-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,15 +72,15 @@ RUN set -ex; \
             cargo \
             cmake \
             python3-dev \
-            apache-arrow-dev=18.1.0 \
+            apache-arrow-dev=18.1.0 --force \
             py3-pip; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
         # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
-        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/requirements.txt; \
+        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/old_requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
-            echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \
+            echo pandas==2.1.4 >> ./projects/extension/old_requirements.txt; \
             # note: no prebuilt binaries for pillow on i386 \
             apk add --no-cache --virtual .pgai-deps-386 \
                 jpeg-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,17 +70,13 @@ RUN set -ex; \
             git \
             build-base \
             cargo \
-            cmake \
             python3-dev \
-            apache-arrow-dev \
             py3-pip; \
         git clone --branch ${PGAI_VERSION} https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
-        # note: this is a hack. pyarrow will be built from source, so must be pinned to this arrow version \
-        echo pyarrow==$(pkg-config --modversion arrow) >> ./projects/extension/old_requirements.txt; \
         if [ "$TARGETARCH" == "386" ]; then \
             # note: pinned because pandas 2.2.0-2.2.3 on i386 is affected by https://github.com/pandas-dev/pandas/issues/59905 \
-            echo pandas==2.1.4 >> ./projects/extension/old_requirements.txt; \
+            echo pandas==2.1.4 >> ./projects/extension/requirements.txt; \
             # note: no prebuilt binaries for pillow on i386 \
             apk add --no-cache --virtual .pgai-deps-386 \
                 jpeg-dev \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ TAG=-t $(TAG_VERSION) $(if $(BETA),,-t $(TAG_LATEST))
 TAG_OSS=-t $(TAG_VERSION)-oss $(if $(BETA),,-t $(TAG_LATEST)-oss)
 
 PGVECTOR_VERSION=v0.7.2
-PGAI_VERSION=extension-0.6.0
+PGAI_VERSION=extension-0.7.0
 
 COMMON_BUILD_ARGS= --build-arg TS_VERSION=$(TS_VERSION) \
 		--build-arg PREV_IMAGE=$(PREV_IMAGE) \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ORG=timescaledev
 PG_VER=pg16
 PG_VER_NUMBER=$(shell echo $(PG_VER) | cut -c3-)
 PG_MAJOR_VERSION=$(shell echo $(PG_VER_NUMBER) | cut -d. -f1)
-ifeq ($(shell test $(PG_MAJOR_VERSION) -ge 17; echo $$?),0)
+ifeq ($(shell test $(PG_MAJOR_VERSION) -ge 16; echo $$?),0)
   ALPINE_VERSION=3.21
   CLANG_VERSION=19
 else


### PR DESCRIPTION
draft PR built on top of [this](https://github.com/timescale/timescaledb-docker/commit/f6e8da6903c78573f51568ad0142b72f347fd143) trying a different approach, bumping
both alpine image and CLANG version for pg16 builds.