### PR TITLE
Use OPTFLAGS="" in pgvector to avoid illegal instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN set -ex; \
         llvm${CLANG_VERSION}; \
     git clone --branch ${PGVECTOR_VERSION} https://github.com/pgvector/pgvector.git /build/pgvector; \
     cd /build/pgvector; \
-    make; \
+    make OPTFLAGS=""; \
     make install; \
     apk del .vector-deps;
 


### PR DESCRIPTION
On MacOS (M3) running timescaledb images (linux/arm64) with pgvector makes postgres crash with "was terminated by signal 4: Illegal instruction".

`OPTFLAGS=""` disables using `-march=native` that could have problems when the CPU that runs the docker image is different (missing instructions).

https://github.com/pgvector/pgvector/issues/389

The official pgvector docker builds also use `make OPTFLAGS=""`:

https://github.com/pgvector/pgvector/blob/6ef7fccb5cd2ec89bb98692ea9c3507f9ac58c84/Dockerfile#L15

I have tested this localy and it works (no more crashes):

```
docker buildx build --platform linux/arm64 --build-arg TS_VERSION=2.18.1 --build-arg PREV_IMAGE=timescale/timescaledb:2.18.1-pg16 --build-arg PG_VERSION=16 --build-arg PG_MAJOR_VERSION=16 --build-arg ALPINE_VERSION=3.21 --build-arg CLANG_VERSION=19 --build-arg PGVECTOR_VERSION=v0.7.2 -t timescale/timescaledb:2.18.1-pg16 .
```