### PR TITLE
Bump go version to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG ALPINE_VERSION
 ############################
 # Build tools binaries in separate image
 ############################
-ARG GO_VERSION=1.22.4
+ARG GO_VERSION=1.26.2
 FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.8.1


### PR DESCRIPTION
timescaledb-tune now requires >= 1.23 so bump to latest go version
