### PR TITLE
Remove PG15 from nightly docker build

### DIFF
--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [15, 16, 17, 18]
+        pg: [16, 17, 18]
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Timescaledb main no longer supports PG15
